### PR TITLE
feat: Add retry button to result pages

### DIFF
--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -12,11 +12,11 @@ function Card() {
 
   const [questionIndex, setQuestionIndex] = useState(0); // 현재 문제의 인덱스
   const location = useLocation();
-  const questions = location.state.questions;
-  const tags = location.state.tags;
+  const questions = [...location.state.questions];
+  const tags = [...location.state.tags];
   const navigate = useNavigate();
-  const today = new Date(); // 오늘 날짜 객체
-  const formattedToday = format(today, 'yyyy-MM-dd'); // 'YYYY-MM-DD' 형식으로 포맷
+  const today = new Date(); 
+  const formattedToday = format(today, 'yyyy-MM-dd'); 
 
   // Recoil 수정
   const setRecoilQuestions = useSetRecoilState(questionsAtom);
@@ -63,6 +63,8 @@ function Card() {
     const currentLevel = currentQuestion.level ? parseInt(currentQuestion.level, 10) : 0;
     const newLevel = Math.min(currentLevel + 1, 3); // 레벨 증가 (최대 3)
     const newUpdateDate = calculateUpdateDate(today, newLevel);
+
+    currentQuestion.selected = currentQuestion.answer;
 
     setCorrectCount((prevCount) => {
       const updatedCount = prevCount + 1;

--- a/src/pages/solve/CardResult.js
+++ b/src/pages/solve/CardResult.js
@@ -2,6 +2,8 @@ import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Doughnut } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -12,6 +14,29 @@ function CardResult() {
   const result = location.state.result;
   const navigate = useNavigate();
   const goCard = () => { navigate("/card", { state :  { "questions" : questions, "tags" : tags }})}
+  const retryWrongQuestions = () => { 
+    const retryTags = new Set();
+    const retryQuestions = questions.filter((item) => item.answer !== item.selected);
+    retryQuestions.forEach((item) => {
+      if (item.tag) {
+        item.tag.forEach((tag) => retryTags.add(tag));
+      }
+    });
+
+    if(retryQuestions.length <= 0) {
+      if (!toast.isActive("no-question-retry-error")) {
+        toast.error("다시 풀 문제가 없습니다!", { toastId: "no-question-retry-error" });
+      } 
+      return;
+    }
+
+    navigate("/card", { 
+      state :  { 
+        "questions" : retryQuestions, 
+        "tags" : retryTags 
+      }
+    }
+  )}
   const goDashBoard = () => { navigate("/dashboard")}
 
   
@@ -50,7 +75,10 @@ function CardResult() {
 
         <div className="hidden p-4 flex justify-between border-b">
           <div>
-            <h1 className="text-2xl font-semibold">{tags.map((tag) => tag + " ")}</h1>
+            <h1 className="text-2xl font-semibold">
+              {tags.length == 0 && "문제 결과"}
+              {tags.map((tag) => tag + " ")}
+            </h1>
             <h1 className="text-md font-normal text-gray-400">{questions.length} 문제</h1>
           </div>
         </div>
@@ -58,22 +86,32 @@ function CardResult() {
         <div className="my-auto flex-1 flex flex-col gap-2 p-10 items-center">
             <div className="flex flex-col w-3/4 h-[400px] bg-white rounded-2xl shadow flex justify-around">
               <div>
-                <div className="font-bold text-xl text-center">{tags.map((tag) => tag + " ")}</div>
+                <div className="font-bold text-xl text-center">
+                  {tags.length == 0 && "문제 결과"}
+                  {tags.map((tag) => tag + " ")}
+                </div>
                 <div className="text-sm font-semibold text-gray-400 text-center mt-1">총 {questions.length}문제 중 {result.correct}문제를 맞췄어요</div>
               </div>
               <div className="mt-2 h-1/2">
                   <Doughnut data={data} options={options} />
               </div>
               <div className="flex justify-between w-full px-5">
+                <div className="flex gap-1">
+                  <div 
+                    onClick={goCard}
+                    className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">
+                      전체 다시풀기
+                    </div>
+                  <div 
+                    onClick={retryWrongQuestions}
+                    className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">
+                      오답 다시풀기
+                  </div>
+                </div>
                 <div 
-                onClick={goCard}
-                className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">다시풀기</div>
-              
-              <div 
-                onClick={goDashBoard}
-                className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">완료</div>
-            
-              </div>
+                  onClick={goDashBoard}
+                  className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">완료</div>
+                </div>
               
             </div>
         </div>

--- a/src/pages/solve/SolveResult.js
+++ b/src/pages/solve/SolveResult.js
@@ -2,7 +2,8 @@ import React, { useRef } from "react";
 import { useSetRecoilState } from "recoil";
 import { Doughnut, Bar } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from "chart.js";
-
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import { useNavigate, useLocation } from "react-router-dom";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
@@ -145,14 +146,31 @@ function SolveResult() {
 
   const navigate = useNavigate();
 
-  const retry = () => {
+  const retryAll = () => {
+    const retryTags = new Set();
+    const retryQuestions = [...answers];
+    
+     // 틀린 문제에서 태그 값을 Set에 추가
+    retryQuestions.forEach((item) => {
+      if (item.tag) {
+        item.tag.forEach((tag) => retryTags.add(tag)); // 중복 없이 태그 추가
+      }
+    });
+
+    navigate("/solve", {
+      state: { questions: retryQuestions, tags: [...retryTags] },
+    });
+  
+  }
+
+  const retryWrongQuestions = () => {
     const retryTags = new Set();
     const retryQuestions = answers.filter((item) => item.answer !== item.selected);
     
     if(retryQuestions.length <= 0){
-      // if (!toast.isActive("no-question-error")) {
-      //         toast.error("현재 풀이 가능한 문제가 없습니다! 문제를 생성해주세요", { toastId: "no-question-error" });
-      // } 
+      if (!toast.isActive("no-question-retry-error")) {
+        toast.error("다시 풀 문제가 없습니다!", { toastId: "no-question-retry-error" });
+      } 
       return;
     }
      // 틀린 문제에서 태그 값을 Set에 추가
@@ -167,7 +185,6 @@ function SolveResult() {
     });
   
   }
-
 
   return (
     <main className="ml-20">
@@ -205,10 +222,16 @@ function SolveResult() {
             </svg>
           </div>
           <div
-              onClick={retry}
+              onClick={retryAll}
               className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
             >
-              다시풀기
+              전체 다시풀기
+          </div>
+          <div
+              onClick={retryWrongQuestions}
+              className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
+            >
+              오답 다시풀기
           </div>
           </div>
         </div>


### PR DESCRIPTION
## #️⃣ 관련 이슈
<!-- 
관련된 이슈 번호를 링크하거나 언급해주세요.
예: Closes #12, #34
-->

#12 

## 📝 작업 내용
<!-- 
이번 PR에서 작업한 내용을 항목별로 설명해주세요(이미지 첨부 가능)
예:
- 로그인 API (`POST /api/login`) 추가
- JWT 토큰 발급 로직 구현
- UserService 리팩토링
-->

- 시험 결과 페이지에서 오답 다시풀기 버튼 / 전체 다시풀기 버튼이 나눠집니다.
<img width="887" height="588" alt="시험결과오답다시풀기" src="https://github.com/user-attachments/assets/ad94deaa-9fbe-4fe3-b804-077c1ccab600" />

- 카드 결과 페이지에서 오답 다시풀기 버튼 / 전체 다시풀기 버튼이 나눠집니다.
<img width="889" height="591" alt="카드결과오답다시풀기" src="https://github.com/user-attachments/assets/e2822246-dd05-4470-a850-98f2453d75c6" />


## ✅ 테스트 결과
<!-- 
직접 테스트한 내용이나 결과를 작성해주세요.
예:
- [x] 정상 로그인 시 토큰 발급 확인
- [x] 잘못된 비밀번호로 401 응답 확인
-->
- [x] 실제 오답만 다시 풀기가 되는지 확인
- [x] 오답이 없을 경우 예외처리 확인 


## 💬 리뷰 요구사항(선택)
<!-- 
리뷰어가 이해를 위해 알아야 할 점, 
혹은 후속작업이 필요한 항목,
특별히 봐주었으면 하는 부분이 있다면 작성해주세요
예: 
메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
기존 보안 로직을 변경했으므로 side effect 가능성 있음
-->
