### PR TITLE
feat: apply sandbox and restrict external navigation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
-import { app } from 'electron';
+import { app, shell } from 'electron';
 import { updateRecommendDates } from './controllers/questionController.js';
-import { createWindow, getMainWindow } from './services/windowService.js';
+import { createWindow, getMainWindow, applyNavigationPolicy } from './services/windowService.js';
 import { setupAutoUpdater } from './services/updateService.js';
 import { setupIpcHandlers } from './handlers/ipcHandlers.js';
 import { getSettingFile } from './services/settingService.js';
@@ -30,4 +30,8 @@ app.on("activate", () => {
   if (getMainWindow() === null) {
     createWindow();
   }
+});
+
+app.on("web-contents-created", (_event, contents) => {
+  applyNavigationPolicy(contents);
 });

--- a/src/services/windowService.js
+++ b/src/services/windowService.js
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, shell } from 'electron';
 import path from 'path';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -58,4 +58,42 @@ export async function createWindow() {
  */
 export function getMainWindow() {
   return mainWindow;
+}
+
+
+// 허용 url
+export const isAllowedInApp = (urlString) => {
+  try {
+    const url = new URL(urlString);
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") return true;
+
+    const host = url.hostname.toLowerCase();
+
+    if (host === "github.com" || host.endsWith(".github.com")) return true;
+
+    if (host === "githubassets.com" || host.endsWith(".githubassets.com")) return true;
+    if (host === "githubusercontent.com" || host.endsWith(".githubusercontent.com")) return true;
+
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+// 정책
+export function applyNavigationPolicy(contents) {
+  contents.setWindowOpenHandler(({ url }) => {
+    if (isAllowedInApp(url)) return { action: "allow" };
+
+    shell.openExternal(url);
+    return { action: "deny" };
+  });
+
+  contents.on("will-navigate", (event, url) => {
+    if (isAllowedInApp(url)) return;
+
+    event.preventDefault();
+    shell.openExternal(url);
+  });
 }


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
- #34 

## 📝 작업 내용
- Renderer Process에 **Sandbox 환경**을 적용하고 `nodeIntegration`을 false로 설정
- **Allow List 기반 URL 접근 정책**을 적용하여 Renderer Process 내에서 허용된 URL만 로드되도록 제한
  - 허용되지 않은 외부 사이트는 **시스템 브라우저를 통해서만 실행**되도록 처리
 
## ✅ 테스트 결과
- [x] 빌드 테스트 완료
- [x] 이미지 정상 노출 확인
- [x] GitHub 도메인 접근 시 Renderer Process 내 실행 확인
- [x] Allow List에 포함되지 않은 외부 사이트는 시스템 브라우저로 정상 실행 확인

## 🔎 참고할만한 자료

- [ADR-001 보안 하드닝](https://github.com/HowAboutQuestion/static-site/blob/main/decisions/ADR-001%20%EB%B3%B4%EC%95%88%20%ED%95%98%EB%93%9C%EB%8B%9D.md)
- [ADR-002 보안 관련 URL](https://github.com/HowAboutQuestion/static-site/blob/main/decisions/ADR-002%20%EB%B3%B4%EC%95%88%20%EA%B4%80%EB%A0%A8%20URL.md)
