### PR TITLE
fix: truncate long title with ellipsis in card solve screen

### DIFF
--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -156,7 +156,7 @@ function Card() {
   const closeModal = () => setIsModalOpen(false);
 
   return (
-    <main className="ml-20 h-[100vh]">
+    <main className="ml-20 h-[100vh] overflow-x-hidden">
       <div className="sm:rounded-lg h-full flex flex-col">
         <div className="p-4 flex justify-between border-b">
           <div>
@@ -194,16 +194,16 @@ function Card() {
           )}
 
           {!questions[questionIndex].img && (
-            <div className="w-3/4 h-[300px] bg-white rounded-2xl">
+            <div className="w-3/4 h-[300px] bg-white rounded-2xl overflow-hidden">
               <div
                 style={{
-                  fontSize: "clamp(0.8rem, 2vw, 1.3rem)", 
+                  fontSize: "clamp(0.8rem, 2vw, 1.3rem)",
                 }}
                 className="w-full text-center text-lg font-bold mt-10 px-3">
                 {questions[questionIndex].title}
               </div>
 
-              <div className="w-full text-md whitespace-nowrap font-semibold mt-5 text-gray-500 flex justify-center items-center">
+              <div className="w-full text-md font-semibold mt-5 text-gray-500 flex justify-center items-center">
                 {showAnswer && <div>
                   <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkBreaks]}>
                    {questions[questionIndex].answer}

--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -159,17 +159,17 @@ function Card() {
     <main className="ml-20 h-[100vh] overflow-x-hidden">
       <div className="sm:rounded-lg h-full flex flex-col">
         <div className="p-4 flex justify-between border-b">
-          <div>
+          <div className="flex-1 min-w-0">
             <div className="relative group w-full">
-                  <h1 className="truncate text-2xl font-semibold overflow-hidden">
-                    {tags.length === 0 && "문제 풀이 결과"}
-                    {tags.map((tag) => `${tag} `)}
-                  </h1>
-                  <span className="opacity-50 absolute top-full left-0 mt-1 hidden group-hover:block bg-gray-800 text-white text-sm rounded px-2 py-1 whitespace-pre-wrap z-10">
-                    {tags.length === 0 ? "문제 풀이 결과" : tags.join(" ")}
-                  </span>
-              </div>
-            <h1 className=" text-md font-normal text-gray-400">총 {questions.length} 문제</h1>
+              <h1 className="truncate text-2xl font-semibold overflow-hidden">
+                {tags.length === 0 && "문제 풀이"}
+                {tags.map((tag) => `${tag} `)}
+              </h1>
+              <span className="opacity-50 absolute top-full left-0 mt-1 hidden group-hover:block bg-gray-800 text-white text-sm rounded px-2 py-1 whitespace-pre-wrap z-10">
+                {tags.length === 0 ? "문제 풀이" : tags.join(" ")}
+              </span>
+            </div>
+            <h1 className="text-md font-normal text-gray-400">총 {questions.length} 문제</h1>
           </div>
         </div>
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #53  

## 📝 작업 내용
- 카드 시험 결과에서 문구가 길어진 경우 좌우 스크롤이 발생해 프레임이 깨지는 현상을 `...`로 처리하였습니다.

## ✅ 테스트 결과
- [x] 빌드 테스트 완료