### PR TITLE
style: remove dark mode styles

### DIFF
--- a/src/pages/dashboard/DashboardStats.js
+++ b/src/pages/dashboard/DashboardStats.js
@@ -30,14 +30,14 @@ const DashboardStats = ({
         </div>
       </section>
       <section data-tour-id="dashboard-graph">
-        <div className="h-auto mb-4 rounded bg-gray-50 dark:bg-gray-800 p-6">
+        <div className="h-auto mb-4 rounded bg-gray-50 p-6">
           <div className="flex flex-col items-start w-full">
-            <p className="text-lg font-bold text-gray-800 dark:text-white">정답률</p>
-            <p className="text-4xl font-extrabold text-gray-900 dark:text-white mt-2">
+            <p className="text-lg font-bold text-gray-800">정답률</p>
+            <p className="text-4xl font-extrabold text-gray-900 mt-2">
               {todayCorrectRate}% 맞춤!
             </p>
             <div className="flex items-center mt-1">
-              <p className="text-sm text-gray-500 dark:text-gray-400 mr-1">어제보다</p>
+              <p className="text-sm text-gray-500 mr-1">어제보다</p>
               <p className={`text-sm font-medium ${rateChange >= 0 ? 'text-green-500' : 'text-red-500'}`}>
                 {rateChange >= 0 ? `+${rateChange}%` : `${rateChange}%`}
               </p>

--- a/src/pages/notice/Helper.js
+++ b/src/pages/notice/Helper.js
@@ -198,7 +198,7 @@ const Helper = ({ closeHelper }) => {
               href="https://github.com/HowAboutQuestion/Lagacy-HowAboutQuestion/discussions"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-lg font-bold text-gray-800 dark:text-white mb-2 hover:underline"
+              className="text-lg font-bold text-gray-800 mb-2 hover:underline"
             >
               HowAboutQuestion
             </a>

--- a/src/pages/notice/Notice.js
+++ b/src/pages/notice/Notice.js
@@ -53,7 +53,7 @@ const Notice = ({ closeNotice }) => {
               href="https://github.com/HowAboutQuestion/Lagacy-HowAboutQuestion/discussions"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-lg font-bold text-gray-800 dark:text-white mb-2 hover:underline"
+              className="text-lg font-bold text-gray-800 mb-2 hover:underline"
             >
               HowAboutQuestion
             </a>

--- a/src/pages/question/QuestionItem.js
+++ b/src/pages/question/QuestionItem.js
@@ -119,7 +119,7 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
                 checked={!!isChecked} // boolean
                 onChange={onChangeCheckbox}
                 onClick={(e) => e.stopPropagation()}
-                className="w-4 h-4 text-blue-600 cursor-pointer bg-gray-100 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 dark:focus:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                className="w-4 h-4 text-blue-600 cursor-pointer bg-gray-100 rounded focus:ring-blue-500 focus:ring-2"
               />
             </div>
           </td>
@@ -229,7 +229,7 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
               checked={isChecked}
               onChange={handleCheckboxChange}
               onClick={(e) => e.stopPropagation()}
-              className="cursor-pointer w-4 h-4 text-blue-600 bg-gray-100 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 dark:focus:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+              className="cursor-pointer w-4 h-4 text-blue-600 bg-gray-100 rounded focus:ring-blue-500 focus:ring-2"
             />
           </div>
         </td>

--- a/src/pages/question/QuestionsMain.js
+++ b/src/pages/question/QuestionsMain.js
@@ -187,7 +187,7 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
                   type="checkbox"
                   onChange={handleAllCheckboxChange} // 클릭 시 전체 선택/해제
                   checked={isAllChecked} // 모든 항목이 체크된 상태에 따라 체크박스 상태 변경
-                  className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 dark:focus:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2"
                 />
               </div>
             </th>

--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -239,7 +239,7 @@ function Card() {
             </div>
           )}
 
-          <div className="w-3/4 bg-gray-200 rounded-full h-2 dark:bg-gray-700">
+          <div className="w-3/4 bg-gray-200 rounded-full h-2">
             <div
               className="bg-blue-500 h-2 rounded-full"
               style={{ width: `${((questionIndex + 1) / questions.length) * 100}%` }}


### PR DESCRIPTION

## #️⃣ 관련 이슈
- #55  

## 📝 작업 내용
- 다크 모드 UI를 제거했습니다.
- <img width="796" height="150" alt="image" src="https://github.com/user-attachments/assets/e63272da-0e88-404e-bfe7-26f35d9a013c" />
- <img width="1040" height="632" alt="image" src="https://github.com/user-attachments/assets/b52d20cc-4141-4ef7-966f-89dc3d7e4525" />




## ✅ 테스트 결과
- [x] build 테스트 확인

## 💬 리뷰 요구사항(선택)
- `2.0` 버전 배포에 다크 모드도 함께 추가하겠습니다.
