### PR TITLE
fix: improve sidebar performance and UX

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,15 +19,12 @@ const App = () => {
   useEffect(() => {
     const initializeApp = async () => {
       try {
-        console.time("[init] total");
         setAppInitStep("loading");
 
-        console.time("[init] parallel (getUserId + initQuestions)");
         await Promise.all([
           (async () => {
             const id = await window.electronAPI.getUserId();
             setUserId(id);
-            console.log("사용자 id : ", id);
           })(),
           (async () => {
             const result = await window.electronAPI.initQuestions();
@@ -40,10 +37,8 @@ const App = () => {
             }
           })(),
         ]);
-        console.timeEnd("[init] parallel (getUserId + initQuestions)");
 
         setAppInitStep("ready");
-        console.timeEnd("[init] total");
       } catch (error) {
         console.error("앱 초기화 실패: ", error);
         setAppInitStep("error");
@@ -66,7 +61,6 @@ const App = () => {
         if (result && result.appPath) {
           setAppPath(`file:///${result.appPath.replace(/\\/g, "/")}/`);
         }
-        console.log(result);
       } catch (error) {
         console.error("cannot read appPath :", error);
       }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import Papa from 'papaparse';
 import Router from "Router";
 import { useRecoilState } from "recoil";
 import { HashRouter } from "react-router-dom";
@@ -17,110 +16,47 @@ const App = () => {
   const [userId, setUserId] = useRecoilState(userIdAtom);
   const [appInitStep, setAppInitStep] = useRecoilState(appInitStepAtom);
 
-  // CSV 데이터를 비동기적으로 읽어오는 함수
-  const readElectron = async () => {
-    try {
-      // 상태 업데이트 후 비동기적으로 CSV 데이터를 처리
-      const result = await window.electronAPI.readQuestionsCSV();
-      if (result.success) {
-        setAlltag(result.allTag);   // 모든 태그 설정
-        setQuestions(result.questions); // 질문 데이터 설정
-      } else {
-        console.error(result.message);
-      }
-    } catch (error) {
-      console.error('CSV 읽기 실패:', error);
-      setAppInitStep("error");
-    }
-  };
-
-  // setting 파일에서 userId 불러와서 Atom에 넣기 (옵션 추가 되면 그때 수정)
-  const initUserId = async() => {
-    try{
-      const id = await window.electronAPI.getUserId();
-      setUserId(id);
-      console.log("사용자 id : ", id);
-    }catch(error){
-      console.error("사용자 id를 Atom에 넣는 과정에서 문제가 발생했습니다.");
-      setAppInitStep("error");
-    }
-  }
-
-  const recommendations = async () => {
-    try{
-      const result = await window.electronAPI.updateRecommendDates();
-      if(!result.success){
-        console.error(result.message);
-        setAppInitStep("error");
-      }
-    }catch(error) {
-      console.error("추천 날자 보정 실패: ", error);
-      setAppInitStep("error");
-    }
-  };
-
-
   useEffect(() => {
     const initializeApp = async () => {
-      try{
+      try {
         console.time("[init] total");
+        setAppInitStep("loading");
 
-        setAppInitStep("loading-settings");
-        console.time("[init] 1. getUserId");
-        await initUserId();
-        console.timeEnd("[init] 1. getUserId");
-
-        setAppInitStep("loading-questions");
-        console.time("[init] 2. readQuestionsCSV (1st)");
-        await readElectron();
-        console.timeEnd("[init] 2. readQuestionsCSV (1st)");
-
-        setAppInitStep("recommendations");
-        console.time("[init] 3. updateRecommendDates");
-        await recommendations();
-        console.timeEnd("[init] 3. updateRecommendDates");
-
-        setAppInitStep("loading-updateQuestions");
-        console.time("[init] 4. readQuestionsCSV (2nd)");
-        await readElectron();
-        console.timeEnd("[init] 4. readQuestionsCSV (2nd)");
+        console.time("[init] parallel (getUserId + initQuestions)");
+        await Promise.all([
+          (async () => {
+            const id = await window.electronAPI.getUserId();
+            setUserId(id);
+            console.log("사용자 id : ", id);
+          })(),
+          (async () => {
+            const result = await window.electronAPI.initQuestions();
+            if (result.success) {
+              setAlltag(result.allTag);
+              setQuestions(result.questions);
+            } else {
+              console.error(result.message);
+              setAppInitStep("error");
+            }
+          })(),
+        ]);
+        console.timeEnd("[init] parallel (getUserId + initQuestions)");
 
         setAppInitStep("ready");
         console.timeEnd("[init] total");
-      } catch(error) {
+      } catch (error) {
         console.error("앱 초기화 실패: ", error);
         setAppInitStep("error");
       }
     };
 
-    initializeApp()
+    initializeApp();
   }, []);
 
   useEffect(() => {
     const tagSet = new Set();
-    questions.map((question) => question.tag.map((item) => { tagSet.add(item) }));
+    questions.forEach(question => question.tag.forEach(item => tagSet.add(item)));
     setAlltag([...tagSet]);
-
-
-    const updateQuestionsAsync = async () => {
-      try {
-        console.time("[app] ① Papa.unparse (CSV 변환)");
-        const csv = Papa.unparse(
-          questions.map(({ id, checked, ...rest }) => rest)
-        );
-        console.timeEnd("[app] ① Papa.unparse (CSV 변환)");
-
-        console.time("[app] ② writeQuestionsCSV IPC 전체");
-        await window.electronAPI.writeQuestionsCSV(csv);
-        console.timeEnd("[app] ② writeQuestionsCSV IPC 전체");
-      } catch (error) {
-        console.error("[App.js] updateQuestionsAsync", error)
-      }
-    };
-
-    if (questions.length > 0) {
-      updateQuestionsAsync(); // 비동기로 호출
-    }
   }, [questions]);
 
   useEffect(() => {

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import Papa from 'papaparse';
 import Router from "Router";
 import { useRecoilState } from "recoil";
 import { HashRouter } from "react-router-dom";
@@ -62,20 +63,30 @@ const App = () => {
   useEffect(() => {
     const initializeApp = async () => {
       try{
-        // TODO : 메서드 하나 더 추가되면 그때 패턴 적용하거나 정리좀 하기
+        console.time("[init] total");
+
         setAppInitStep("loading-settings");
-        await initUserId(); // setting 값 읽어오기
+        console.time("[init] 1. getUserId");
+        await initUserId();
+        console.timeEnd("[init] 1. getUserId");
 
         setAppInitStep("loading-questions");
-        await readElectron(); // 컴포넌트가 마운트되면 CSV 데이터를 읽기
+        console.time("[init] 2. readQuestionsCSV (1st)");
+        await readElectron();
+        console.timeEnd("[init] 2. readQuestionsCSV (1st)");
 
         setAppInitStep("recommendations");
+        console.time("[init] 3. updateRecommendDates");
         await recommendations();
+        console.timeEnd("[init] 3. updateRecommendDates");
 
         setAppInitStep("loading-updateQuestions");
+        console.time("[init] 4. readQuestionsCSV (2nd)");
         await readElectron();
+        console.timeEnd("[init] 4. readQuestionsCSV (2nd)");
 
         setAppInitStep("ready");
+        console.timeEnd("[init] total");
       } catch(error) {
         console.error("앱 초기화 실패: ", error);
         setAppInitStep("error");
@@ -93,8 +104,15 @@ const App = () => {
 
     const updateQuestionsAsync = async () => {
       try {
-        // 상태 업데이트 후 비동기적으로 questions를 처리
-        const result = await window.electronAPI.updateQuestions(questions);
+        console.time("[app] ① Papa.unparse (CSV 변환)");
+        const csv = Papa.unparse(
+          questions.map(({ id, checked, ...rest }) => rest)
+        );
+        console.timeEnd("[app] ① Papa.unparse (CSV 변환)");
+
+        console.time("[app] ② writeQuestionsCSV IPC 전체");
+        await window.electronAPI.writeQuestionsCSV(csv);
+        console.timeEnd("[app] ② writeQuestionsCSV IPC 전체");
       } catch (error) {
         console.error("[App.js] updateQuestionsAsync", error)
       }

--- a/src/config/paths.js
+++ b/src/config/paths.js
@@ -15,9 +15,6 @@ const historyCsvPath = path.join(userDataPath, 'history.csv');
 const imageDir = path.join(userDataPath, 'images');
 const tempDir = path.join(app.getPath('temp'), 'questions_export');
 
-console.log('questionsCsvPath:', questionsCsvPath);
-console.log('historyCsvPath:', historyCsvPath);
-
 export {
   exeDir,
   userDataPath,

--- a/src/controllers/fileController.js
+++ b/src/controllers/fileController.js
@@ -92,7 +92,7 @@ export async function exportQuestions(questions, savePath) {
     const output = fs.createWriteStream(savePath);
     const archive = archiver('zip', { zlib: { level: 9 } });
 
-    output.on('close', () => console.log(`ZIP file created: ${savePath}`));
+    output.on('close', () => {});
     archive.on('error', (err) => { throw err; });
 
     archive.pipe(output);
@@ -118,7 +118,6 @@ export async function exportQuestions(questions, savePath) {
     await archive.finalize();
     fs.rmSync(tempDir, { recursive: true, force: true });
 
-    console.log("exportQuestions success");
     return { success: true, path: savePath };
   } catch (error) {
     console.error('Error exporting questions:', error);
@@ -244,9 +243,6 @@ export async function extractZip(fileName, content) {
       throw new Error('CSV 파일을 찾을 수 없습니다.');
     }
 
-    console.log("extractZip success");
-
-    // 결과 반환
     result = { success: true, questions };
   } catch (error) {
     result = { success: false, error: error.message };

--- a/src/controllers/fileController.js
+++ b/src/controllers/fileController.js
@@ -14,7 +14,7 @@ import archiver from 'archiver';
 import extract from 'extract-zip';
 import os from 'os';
 import Papa from 'papaparse';
-import { imageDir, tempDir, userDataPath } from '../config/paths.js';
+import { imageDir, tempDir, userDataPath, questionsCsvPath } from '../config/paths.js';
 import { getTodayDate }  from '../utils/dateUtils.js';
 import { generateUniqueId }  from '../utils/idUtils.js';
 
@@ -98,12 +98,17 @@ export async function exportQuestions(questions, savePath) {
     archive.pipe(output);
     archive.file(csvPath, { name: 'questions.csv' });
 
+    const addedImages = new Set();
     for (const question of questions) {
       if (question.img) {
         const imgPath = path.join(userDataPath, question.img);
+        const archiveName = `images/${path.basename(imgPath)}`;
+
+        if (addedImages.has(archiveName)) continue;
 
         if (fs.existsSync(imgPath)) {
-          archive.file(imgPath, { name: `images/${path.basename(imgPath)}` });
+          archive.file(imgPath, { name: archiveName });
+          addedImages.add(archiveName);
         } else {
           console.warn(`Image not found: ${imgPath}`);
         }
@@ -151,8 +156,10 @@ export async function extractZip(fileName, content) {
 
     let csvFilePath = null;
     const questions = [];
+    // basename → absolute path in tempDir
+    const imageMap = new Map();
 
-    // 재귀적으로 디렉토리 탐색
+    // 재귀적으로 디렉토리 탐색 (이미지는 수집만, 아직 복사 안 함)
     const traverseDirectory = (dir) => {
       const files = fs.readdirSync(dir);
 
@@ -160,15 +167,11 @@ export async function extractZip(fileName, content) {
         const filePath = path.join(dir, file);
 
         if (fs.statSync(filePath).isDirectory()) {
-          // 서브 디렉토리 탐색
           traverseDirectory(filePath);
         } else if (file.endsWith('.csv')) {
-          // CSV 파일 발견
           csvFilePath = filePath;
         } else if (/\.(png|jpg|jpeg|gif)$/i.test(file)) {
-          // 이미지 파일 발견
-          const destPath = path.join(imageDir, file);
-          fs.copyFileSync(filePath, destPath);
+          imageMap.set(file, filePath);
         }
       });
     };
@@ -184,7 +187,7 @@ export async function extractZip(fileName, content) {
 
       // PapaParse로 CSV 파싱
       const { data } = Papa.parse(csvData, {
-        header: true, 
+        header: true,
         skipEmptyLines: true,
       });
 
@@ -192,6 +195,21 @@ export async function extractZip(fileName, content) {
       data.forEach(item => {
         const tags = item.tag ? item.tag.split(',').map(tag => tag.trim()) : [];
         tags.forEach(tag => tagSet.add(tag));
+
+        const newId = generateUniqueId();
+
+        // 이미지를 newId.ext 로 리네임해서 저장 → 충돌 없이 1:1 대응
+        let newImgPath = '';
+        if (item.img) {
+          const oldBasename = path.basename(item.img);
+          const srcPath = imageMap.get(oldBasename);
+          if (srcPath) {
+            const ext = path.extname(oldBasename);
+            const newFileName = newId + ext;
+            fs.copyFileSync(srcPath, path.join(imageDir, newFileName));
+            newImgPath = '/images/' + newFileName;
+          }
+        }
 
         questions.push({
           title: item.title || '',
@@ -201,7 +219,7 @@ export async function extractZip(fileName, content) {
           select3: item.select3 || '',
           select4: item.select4 || '',
           answer: item.answer || '',
-          img: item.img || '',
+          img: newImgPath,
           level: 0,
           date: today,
           recommenddate: today,
@@ -209,9 +227,19 @@ export async function extractZip(fileName, content) {
           description: item.description || '',
           solveddate: null,
           tag: tags,
-          id: generateUniqueId(),
+          id: newId,
+          checked: false,
         });
       });
+
+      // 기존 questions.csv 앞에 가져온 문제들을 삽입
+      const existingCsv = fs.readFileSync(questionsCsvPath, 'utf-8');
+      const existingParsed = Papa.parse(existingCsv, { header: true, skipEmptyLines: true });
+      const importedRows = questions.map(({ checked, ...rest }) => ({
+        ...rest,
+        tag: Array.isArray(rest.tag) ? rest.tag.join(',') : rest.tag,
+      }));
+      fs.writeFileSync(questionsCsvPath, Papa.unparse([...importedRows, ...existingParsed.data]), 'utf-8');
     } else {
       throw new Error('CSV 파일을 찾을 수 없습니다.');
     }
@@ -219,7 +247,7 @@ export async function extractZip(fileName, content) {
     console.log("extractZip success");
 
     // 결과 반환
-    result = { success: true, questions, csvFile: csvFilePath };
+    result = { success: true, questions };
   } catch (error) {
     result = { success: false, error: error.message };
   } finally {

--- a/src/controllers/historyController.js
+++ b/src/controllers/historyController.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview
- * 이 모듈은 history CSV 파일을 읽고 업데이트하는 함수들을 제공합니다. 
- * 이 파일은 퀴즈 시도에 대한 통계(문제 풀이 수, 정답 수, 정답률)를 매일 기록합니다. 
+ * 이 모듈은 history CSV 파일을 읽고 업데이트하는 함수들을 제공합니다.
+ * 이 파일은 퀴즈 시도에 대한 통계(문제 풀이 수, 정답 수, 정답률)를 매일 기록합니다.
  * CSV 파일은 존재하지 않으면 새로 생성하고, 존재하면 기존 데이터를 업데이트합니다.
  */
 
@@ -11,17 +11,8 @@ import { historyCsvPath } from '../config/paths.js';
 import { parseISO, isValid, getTodayDate } from '../utils/dateUtils.js';
 
 
-/**
- * history CSV 파일을 업데이트하는 함수입니다.
- * 오늘 날짜의 퀴즈 결과를 기반으로 해결된 문제 수와 정답 수를 업데이트합니다.
- * 만약 오늘 날짜의 기록이 없다면 새로운 레코드를 추가합니다.
- *
- * @param {boolean} isCorrect - 현재 퀴즈가 정답이었는지 여부.
- * @returns {Object} - 성공 여부와 메시지를 포함한 객체.
- */
 export function updateHistory(isCorrect) {
   try {
-    console.time("[updateHistory] total (Main)");
     const today = getTodayDate();
 
     if (!existsSync(historyCsvPath)) {
@@ -31,22 +22,13 @@ export function updateHistory(isCorrect) {
         correctCount: isCorrect ? 1 : 0,
         correctRate: isCorrect ? 100.0 : 0.0
       }];
-      const csv = Papa.unparse(initialData);
-      writeFileSync(historyCsvPath, csv, 'utf-8');
-      console.timeEnd("[updateHistory] total (Main)");
-      console.log(`history.csv에 새로운 날짜(${today}) 기록이 추가되었습니다.`);
+      writeFileSync(historyCsvPath, Papa.unparse(initialData), 'utf-8');
       return { success: true, message: '새로운 기록이 추가되었습니다.' };
     }
 
-    console.time("[updateHistory] readFileSync");
     const csvFile = readFileSync(historyCsvPath, 'utf-8');
-    console.timeEnd("[updateHistory] readFileSync");
-
-    console.time("[updateHistory] Papa.parse");
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
-    console.timeEnd("[updateHistory] Papa.parse");
 
-    console.time("[updateHistory] map");
     let rowFound = false;
     const updatedData = parsed.data.map(row => {
       if (row.date === today) {
@@ -59,7 +41,6 @@ export function updateHistory(isCorrect) {
       }
       return row;
     });
-    console.timeEnd("[updateHistory] map");
 
     if (!rowFound) {
       updatedData.push({
@@ -70,13 +51,7 @@ export function updateHistory(isCorrect) {
       });
     }
 
-    console.time("[updateHistory] Papa.unparse+writeFileSync");
-    const newCsv = Papa.unparse(updatedData);
-    writeFileSync(historyCsvPath, newCsv, 'utf-8');
-    console.timeEnd("[updateHistory] Papa.unparse+writeFileSync");
-
-    console.timeEnd("[updateHistory] total (Main)");
-    console.log(`history.csv의 ${today} 날짜 기록이 업데이트되었습니다.`);
+    writeFileSync(historyCsvPath, Papa.unparse(updatedData), 'utf-8');
     return { success: true, message: 'history.csv가 성공적으로 업데이트되었습니다.' };
   } catch (error) {
     console.error('history.csv 업데이트 중 오류 발생:', error);
@@ -84,12 +59,6 @@ export function updateHistory(isCorrect) {
   }
 }
 
-/**
- * history CSV 파일을 읽어 데이터를 반환하는 함수입니다.
- * 각 날짜별로 해결된 문제 수, 정답 수, 정답률을 포함한 데이터를 반환합니다.
- *
- * @returns {Object} - 성공 여부, history 데이터, 메시지를 포함한 객체.
- */
 export function readHistoryCSV() {
   try {
     if (!existsSync(historyCsvPath)) {
@@ -97,13 +66,7 @@ export function readHistoryCSV() {
       return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
     }
 
-    console.time("[readHistoryCSV] total (Main)");
-
-    console.time("[readHistoryCSV] readFileSync");
     const csvFile = readFileSync(historyCsvPath, 'utf-8');
-    console.timeEnd("[readHistoryCSV] readFileSync");
-
-    console.time("[readHistoryCSV] Papa.parse+map");
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
     const historyData = parsed.data
       .map(row => {
@@ -115,10 +78,7 @@ export function readHistoryCSV() {
         return { date, solvedCount, correctCount, correctRate };
       })
       .filter(row => row !== null);
-    console.timeEnd("[readHistoryCSV] Papa.parse+map");
 
-    console.timeEnd("[readHistoryCSV] total (Main)");
-    console.log("history.csv read success");
     return { success: true, historyData, message: 'history 읽기 성공' };
   } catch (error) {
     console.error(error);

--- a/src/controllers/historyController.js
+++ b/src/controllers/historyController.js
@@ -21,6 +21,7 @@ import { parseISO, isValid, getTodayDate } from '../utils/dateUtils.js';
  */
 export function updateHistory(isCorrect) {
   try {
+    console.time("[updateHistory] total (Main)");
     const today = getTodayDate();
 
     if (!existsSync(historyCsvPath)) {
@@ -32,13 +33,20 @@ export function updateHistory(isCorrect) {
       }];
       const csv = Papa.unparse(initialData);
       writeFileSync(historyCsvPath, csv, 'utf-8');
+      console.timeEnd("[updateHistory] total (Main)");
       console.log(`history.csv에 새로운 날짜(${today}) 기록이 추가되었습니다.`);
       return { success: true, message: '새로운 기록이 추가되었습니다.' };
     }
 
+    console.time("[updateHistory] readFileSync");
     const csvFile = readFileSync(historyCsvPath, 'utf-8');
-    const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
+    console.timeEnd("[updateHistory] readFileSync");
 
+    console.time("[updateHistory] Papa.parse");
+    const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
+    console.timeEnd("[updateHistory] Papa.parse");
+
+    console.time("[updateHistory] map");
     let rowFound = false;
     const updatedData = parsed.data.map(row => {
       if (row.date === today) {
@@ -51,6 +59,7 @@ export function updateHistory(isCorrect) {
       }
       return row;
     });
+    console.timeEnd("[updateHistory] map");
 
     if (!rowFound) {
       updatedData.push({
@@ -61,9 +70,12 @@ export function updateHistory(isCorrect) {
       });
     }
 
+    console.time("[updateHistory] Papa.unparse+writeFileSync");
     const newCsv = Papa.unparse(updatedData);
     writeFileSync(historyCsvPath, newCsv, 'utf-8');
+    console.timeEnd("[updateHistory] Papa.unparse+writeFileSync");
 
+    console.timeEnd("[updateHistory] total (Main)");
     console.log(`history.csv의 ${today} 날짜 기록이 업데이트되었습니다.`);
     return { success: true, message: 'history.csv가 성공적으로 업데이트되었습니다.' };
   } catch (error) {
@@ -85,7 +97,13 @@ export function readHistoryCSV() {
       return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
     }
 
+    console.time("[readHistoryCSV] total (Main)");
+
+    console.time("[readHistoryCSV] readFileSync");
     const csvFile = readFileSync(historyCsvPath, 'utf-8');
+    console.timeEnd("[readHistoryCSV] readFileSync");
+
+    console.time("[readHistoryCSV] Papa.parse+map");
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
     const historyData = parsed.data
       .map(row => {
@@ -97,9 +115,10 @@ export function readHistoryCSV() {
         return { date, solvedCount, correctCount, correctRate };
       })
       .filter(row => row !== null);
+    console.timeEnd("[readHistoryCSV] Papa.parse+map");
 
+    console.timeEnd("[readHistoryCSV] total (Main)");
     console.log("history.csv read success");
-    console.log(historyData);
     return { success: true, historyData, message: 'history 읽기 성공' };
   } catch (error) {
     console.error(error);

--- a/src/controllers/questionController.js
+++ b/src/controllers/questionController.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview
- * 이 모듈은 questions CSV 파일을 읽고, 업데이트하고, 추천 날짜를 계산하는 함수들을 제공합니다. 
+ * 이 모듈은 questions CSV 파일을 읽고, 업데이트하고, 추천 날짜를 계산하는 함수들을 제공합니다.
  * 이 파일은 문제 목록을 처리하고, 각 문제에 대해 추천 날짜를 업데이트하며, 문제 목록을 새로 저장하는 기능을 제공합니다.
  */
 
@@ -11,30 +11,16 @@ import { getTodayDate, parseISO, isValid, isBefore, isAfter, startOfDay, format 
 import { generateUniqueId } from '../utils/idUtils.js';
 
 
-/**
- * questions CSV 파일을 읽어 문제 목록과 모든 태그를 반환하는 함수입니다.
- * 
- * @returns {Object} - 성공 여부, 모든 태그 목록, 문제 목록 및 메시지를 포함한 객체.
- */
 export function readQuestionsCSV() {
-  console.log("readQuestionsCSV called!");
-
   try {
     if (!existsSync(questionsCsvPath)) {
       console.error(`cannot find questions.csv file: ${questionsCsvPath}`);
       return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
     }
 
-    console.time("[readQuestionsCSV] total (Main)");
-
-    console.time("[readQuestionsCSV] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
-    console.timeEnd("[readQuestionsCSV] readFileSync");
-
     let questions = [];
     const tagSet = new Set();
-
-    console.time("[readQuestionsCSV] Papa.parse+map");
     let needsMigration = false;
     const existingIds = new Set();
 
@@ -60,12 +46,10 @@ export function readQuestionsCSV() {
           item.checked = false;
           return item;
         });
-        console.timeEnd("[readQuestionsCSV] Papa.parse+map");
       },
     });
 
     if (needsMigration) {
-      console.log("[readQuestionsCSV] id 컬럼 마이그레이션 실행");
       const migratedCsv = Papa.unparse(
         questions.map(({ checked, ...rest }) => ({
           ...rest,
@@ -74,9 +58,6 @@ export function readQuestionsCSV() {
       );
       writeFileSync(questionsCsvPath, migratedCsv, 'utf-8');
     }
-
-    console.timeEnd("[readQuestionsCSV] total (Main)");
-    console.log("questions read success");
 
     return {
       success: true,
@@ -90,31 +71,20 @@ export function readQuestionsCSV() {
   }
 }
 
-/**
- * 앱 초기화용: CSV 읽기 + id 마이그레이션 + 추천날짜 갱신 + 쓰기를 한 번에 처리합니다.
- */
 export function initQuestions() {
   try {
     if (!existsSync(questionsCsvPath)) {
       return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
     }
 
-    console.time("[initQuestions] total (Main)");
-
-    console.time("[initQuestions] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
-    console.timeEnd("[initQuestions] readFileSync");
-
-    console.time("[initQuestions] Papa.parse");
     const { data } = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
-    console.timeEnd("[initQuestions] Papa.parse");
 
     const today = getTodayDate();
     const todayDate = parseISO(today);
     let needsWrite = false;
     const existingIds = new Set();
 
-    console.time("[initQuestions] map+updateDates");
     const updatedRows = data.map(row => {
       if (!row.id) {
         let newId;
@@ -140,25 +110,17 @@ export function initQuestions() {
 
       return row;
     });
-    console.timeEnd("[initQuestions] map+updateDates");
 
     if (needsWrite) {
-      console.time("[initQuestions] Papa.unparse+writeFileSync");
       writeFileSync(questionsCsvPath, Papa.unparse(updatedRows), 'utf-8');
-      console.timeEnd("[initQuestions] Papa.unparse+writeFileSync");
     }
 
-    console.time("[initQuestions] toQuestions");
     const tagSet = new Set();
     const questions = updatedRows.map(row => {
       const tags = row.tag ? row.tag.split(',').map(t => t.trim()) : [];
       tags.forEach(t => tagSet.add(t));
       return { ...row, description: row.description || '', tag: tags, checked: false };
     });
-    console.timeEnd("[initQuestions] toQuestions");
-
-    console.timeEnd("[initQuestions] total (Main)");
-    console.log("initQuestions success");
 
     return { success: true, allTag: [...tagSet], questions };
   } catch (error) {
@@ -167,12 +129,6 @@ export function initQuestions() {
   }
 }
 
-/**
- * questions CSV 파일에서 추천 날짜를 업데이트하는 함수입니다.
- * 오늘 날짜를 기준으로 문제의 추천 날짜를 계산하여 업데이트합니다.
- *
- * @returns {Object} - 성공 여부와 메시지를 포함한 객체.
- */
 export function updateRecommendDates() {
   try {
     if (!existsSync(questionsCsvPath)) {
@@ -180,27 +136,17 @@ export function updateRecommendDates() {
       return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
     }
 
-    console.time("[updateRecommendDates] total (Main)");
-
-    console.time("[updateRecommendDates] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
-    console.timeEnd("[updateRecommendDates] readFileSync");
-
-    console.time("[updateRecommendDates] Papa.parse");
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
-    console.timeEnd("[updateRecommendDates] Papa.parse");
 
     const today = getTodayDate();
     const todayDate = parseISO(today);
 
-    console.time("[updateRecommendDates] map");
     const updatedData = parsed.data.map(row => {
       const recommendDate = parseISO(row.recommenddate);
       const updateDate = parseISO(row.update);
 
-      if (!isValid(recommendDate) || !isValid(updateDate)) {
-        return row;
-      }
+      if (!isValid(recommendDate) || !isValid(updateDate)) return row;
 
       if (isBefore(startOfDay(recommendDate), todayDate)) {
         if (isAfter(startOfDay(updateDate), todayDate)) {
@@ -212,15 +158,8 @@ export function updateRecommendDates() {
 
       return row;
     });
-    console.timeEnd("[updateRecommendDates] map");
 
-    console.time("[updateRecommendDates] Papa.unparse+writeFileSync");
-    const newCsv = Papa.unparse(updatedData);
-    writeFileSync(questionsCsvPath, newCsv, 'utf-8');
-    console.timeEnd("[updateRecommendDates] Papa.unparse+writeFileSync");
-
-    console.timeEnd("[updateRecommendDates] total (Main)");
-    console.log('recommenddate update success');
+    writeFileSync(questionsCsvPath, Papa.unparse(updatedData), 'utf-8');
     return { success: true, message: 'recommenddate가 성공적으로 업데이트되었습니다.' };
   } catch (error) {
     console.error('Error updating recommend dates:', error);
@@ -228,17 +167,8 @@ export function updateRecommendDates() {
   }
 }
 
-/**
- * 문제 목록을 기반으로 questions CSV 파일을 업데이트하는 함수입니다.
- * 
- * @param {Array} questions - 업데이트할 문제 목록.
- * @returns {Object} - 성공 여부를 포함한 객체.
- */
 export function updateQuestionsFile(questions) {
-  console.log("updateQuestionsFile called!");
-
   try {
-    console.time("[updateQuestionsFile] Papa.unparse+writeFileSync");
     const csvString = Papa.unparse(
       questions.map(question => {
         const { id, checked, ...rest } = question;
@@ -246,7 +176,6 @@ export function updateQuestionsFile(questions) {
       })
     );
     writeFileSync(questionsCsvPath, csvString, 'utf-8');
-    console.timeEnd("[updateQuestionsFile] Papa.unparse+writeFileSync");
     return { success: true };
   } catch (error) {
     console.error('CSV update error:', error);
@@ -255,11 +184,8 @@ export function updateQuestionsFile(questions) {
 }
 
 export function writeQuestionsCSVFile(csv) {
-  console.log("writeQuestionsCSVFile called!");
   try {
-    console.time("[writeQuestionsCSVFile] writeFileSync");
     writeFileSync(questionsCsvPath, csv, 'utf-8');
-    console.timeEnd("[writeQuestionsCSVFile] writeFileSync");
     return { success: true };
   } catch (error) {
     console.error('CSV write error:', error);
@@ -277,19 +203,10 @@ function serializeRow(question) {
 
 export function appendQuestionToCSV(question) {
   try {
-    console.time("[appendQuestionToCSV] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
-    console.timeEnd("[appendQuestionToCSV] readFileSync");
-
-    console.time("[appendQuestionToCSV] Papa.parse+unshift");
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
     parsed.data.unshift(serializeRow(question));
-    console.timeEnd("[appendQuestionToCSV] Papa.parse+unshift");
-
-    console.time("[appendQuestionToCSV] Papa.unparse+writeFileSync");
     writeFileSync(questionsCsvPath, Papa.unparse(parsed.data), 'utf-8');
-    console.timeEnd("[appendQuestionToCSV] Papa.unparse+writeFileSync");
-
     return { success: true };
   } catch (error) {
     console.error('appendQuestionToCSV error:', error);
@@ -299,22 +216,13 @@ export function appendQuestionToCSV(question) {
 
 export function updateQuestionInCSV(partialQuestion) {
   try {
-    console.time("[updateQuestionInCSV] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
-    console.timeEnd("[updateQuestionInCSV] readFileSync");
-
-    console.time("[updateQuestionInCSV] Papa.parse+map");
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
     const incoming = serializeRow(partialQuestion);
     parsed.data = parsed.data.map(row =>
       row.id === partialQuestion.id ? { ...row, ...incoming } : row
     );
-    console.timeEnd("[updateQuestionInCSV] Papa.parse+map");
-
-    console.time("[updateQuestionInCSV] Papa.unparse+writeFileSync");
     writeFileSync(questionsCsvPath, Papa.unparse(parsed.data), 'utf-8');
-    console.timeEnd("[updateQuestionInCSV] Papa.unparse+writeFileSync");
-
     return { success: true };
   } catch (error) {
     console.error('updateQuestionInCSV error:', error);
@@ -324,21 +232,11 @@ export function updateQuestionInCSV(partialQuestion) {
 
 export function deleteQuestionsFromCSV(ids) {
   try {
-    console.time("[deleteQuestionsFromCSV] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
-    console.timeEnd("[deleteQuestionsFromCSV] readFileSync");
-
-    console.time("[deleteQuestionsFromCSV] Papa.parse+filter");
     const idSet = new Set(ids);
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
     parsed.data = parsed.data.filter(row => !idSet.has(row.id));
-    console.timeEnd("[deleteQuestionsFromCSV] Papa.parse+filter");
-
-    console.time("[deleteQuestionsFromCSV] Papa.unparse+writeFileSync");
     writeFileSync(questionsCsvPath, Papa.unparse(parsed.data), 'utf-8');
-    console.timeEnd("[deleteQuestionsFromCSV] Papa.unparse+writeFileSync");
-
-    console.log(`[deleteQuestionsFromCSV] ${ids.length}개 삭제 완료`);
     return { success: true };
   } catch (error) {
     console.error('deleteQuestionsFromCSV error:', error);

--- a/src/controllers/questionController.js
+++ b/src/controllers/questionController.js
@@ -35,6 +35,9 @@ export function readQuestionsCSV() {
     const tagSet = new Set();
 
     console.time("[readQuestionsCSV] Papa.parse+map");
+    let needsMigration = false;
+    const existingIds = new Set();
+
     Papa.parse(csvFile, {
       header: true,
       skipEmptyLines: true,
@@ -46,13 +49,31 @@ export function readQuestionsCSV() {
 
           item.tag.forEach(t => tagSet.add(t));
 
-          item.id = generateUniqueId();
+          if (!item.id) {
+            let newId;
+            do { newId = `id-${Math.random().toString(36).slice(2, 11)}`; }
+            while (existingIds.has(newId));
+            item.id = newId;
+            needsMigration = true;
+          }
+          existingIds.add(item.id);
           item.checked = false;
           return item;
         });
         console.timeEnd("[readQuestionsCSV] Papa.parse+map");
       },
     });
+
+    if (needsMigration) {
+      console.log("[readQuestionsCSV] id 컬럼 마이그레이션 실행");
+      const migratedCsv = Papa.unparse(
+        questions.map(({ checked, ...rest }) => ({
+          ...rest,
+          tag: Array.isArray(rest.tag) ? rest.tag.join(',') : rest.tag,
+        }))
+      );
+      writeFileSync(questionsCsvPath, migratedCsv, 'utf-8');
+    }
 
     console.timeEnd("[readQuestionsCSV] total (Main)");
     console.log("questions read success");
@@ -66,6 +87,83 @@ export function readQuestionsCSV() {
   } catch (error) {
     console.error(error);
     return { success: false, message: 'questions read fail' };
+  }
+}
+
+/**
+ * 앱 초기화용: CSV 읽기 + id 마이그레이션 + 추천날짜 갱신 + 쓰기를 한 번에 처리합니다.
+ */
+export function initQuestions() {
+  try {
+    if (!existsSync(questionsCsvPath)) {
+      return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
+    }
+
+    console.time("[initQuestions] total (Main)");
+
+    console.time("[initQuestions] readFileSync");
+    const csvFile = readFileSync(questionsCsvPath, 'utf-8');
+    console.timeEnd("[initQuestions] readFileSync");
+
+    console.time("[initQuestions] Papa.parse");
+    const { data } = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
+    console.timeEnd("[initQuestions] Papa.parse");
+
+    const today = getTodayDate();
+    const todayDate = parseISO(today);
+    let needsWrite = false;
+    const existingIds = new Set();
+
+    console.time("[initQuestions] map+updateDates");
+    const updatedRows = data.map(row => {
+      if (!row.id) {
+        let newId;
+        do { newId = `id-${Math.random().toString(36).slice(2, 11)}`; }
+        while (existingIds.has(newId));
+        row = { ...row, id: newId };
+        needsWrite = true;
+      }
+      existingIds.add(row.id);
+
+      const recommendDate = parseISO(row.recommenddate);
+      const updateDate = parseISO(row.update);
+
+      if (isValid(recommendDate) && isValid(updateDate) && isBefore(startOfDay(recommendDate), todayDate)) {
+        needsWrite = true;
+        return {
+          ...row,
+          recommenddate: isAfter(startOfDay(updateDate), todayDate)
+            ? format(updateDate, 'yyyy-MM-dd')
+            : today,
+        };
+      }
+
+      return row;
+    });
+    console.timeEnd("[initQuestions] map+updateDates");
+
+    if (needsWrite) {
+      console.time("[initQuestions] Papa.unparse+writeFileSync");
+      writeFileSync(questionsCsvPath, Papa.unparse(updatedRows), 'utf-8');
+      console.timeEnd("[initQuestions] Papa.unparse+writeFileSync");
+    }
+
+    console.time("[initQuestions] toQuestions");
+    const tagSet = new Set();
+    const questions = updatedRows.map(row => {
+      const tags = row.tag ? row.tag.split(',').map(t => t.trim()) : [];
+      tags.forEach(t => tagSet.add(t));
+      return { ...row, description: row.description || '', tag: tags, checked: false };
+    });
+    console.timeEnd("[initQuestions] toQuestions");
+
+    console.timeEnd("[initQuestions] total (Main)");
+    console.log("initQuestions success");
+
+    return { success: true, allTag: [...tagSet], questions };
+  } catch (error) {
+    console.error(error);
+    return { success: false, message: 'initQuestions fail' };
   }
 }
 
@@ -165,6 +263,85 @@ export function writeQuestionsCSVFile(csv) {
     return { success: true };
   } catch (error) {
     console.error('CSV write error:', error);
+    return { success: false, message: error.message };
+  }
+}
+
+function serializeRow(question) {
+  const { checked, ...rest } = question;
+  return {
+    ...rest,
+    ...(Array.isArray(rest.tag) ? { tag: rest.tag.join(',') } : {}),
+  };
+}
+
+export function appendQuestionToCSV(question) {
+  try {
+    console.time("[appendQuestionToCSV] readFileSync");
+    const csvFile = readFileSync(questionsCsvPath, 'utf-8');
+    console.timeEnd("[appendQuestionToCSV] readFileSync");
+
+    console.time("[appendQuestionToCSV] Papa.parse+unshift");
+    const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
+    parsed.data.unshift(serializeRow(question));
+    console.timeEnd("[appendQuestionToCSV] Papa.parse+unshift");
+
+    console.time("[appendQuestionToCSV] Papa.unparse+writeFileSync");
+    writeFileSync(questionsCsvPath, Papa.unparse(parsed.data), 'utf-8');
+    console.timeEnd("[appendQuestionToCSV] Papa.unparse+writeFileSync");
+
+    return { success: true };
+  } catch (error) {
+    console.error('appendQuestionToCSV error:', error);
+    return { success: false, message: error.message };
+  }
+}
+
+export function updateQuestionInCSV(partialQuestion) {
+  try {
+    console.time("[updateQuestionInCSV] readFileSync");
+    const csvFile = readFileSync(questionsCsvPath, 'utf-8');
+    console.timeEnd("[updateQuestionInCSV] readFileSync");
+
+    console.time("[updateQuestionInCSV] Papa.parse+map");
+    const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
+    const incoming = serializeRow(partialQuestion);
+    parsed.data = parsed.data.map(row =>
+      row.id === partialQuestion.id ? { ...row, ...incoming } : row
+    );
+    console.timeEnd("[updateQuestionInCSV] Papa.parse+map");
+
+    console.time("[updateQuestionInCSV] Papa.unparse+writeFileSync");
+    writeFileSync(questionsCsvPath, Papa.unparse(parsed.data), 'utf-8');
+    console.timeEnd("[updateQuestionInCSV] Papa.unparse+writeFileSync");
+
+    return { success: true };
+  } catch (error) {
+    console.error('updateQuestionInCSV error:', error);
+    return { success: false, message: error.message };
+  }
+}
+
+export function deleteQuestionsFromCSV(ids) {
+  try {
+    console.time("[deleteQuestionsFromCSV] readFileSync");
+    const csvFile = readFileSync(questionsCsvPath, 'utf-8');
+    console.timeEnd("[deleteQuestionsFromCSV] readFileSync");
+
+    console.time("[deleteQuestionsFromCSV] Papa.parse+filter");
+    const idSet = new Set(ids);
+    const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
+    parsed.data = parsed.data.filter(row => !idSet.has(row.id));
+    console.timeEnd("[deleteQuestionsFromCSV] Papa.parse+filter");
+
+    console.time("[deleteQuestionsFromCSV] Papa.unparse+writeFileSync");
+    writeFileSync(questionsCsvPath, Papa.unparse(parsed.data), 'utf-8');
+    console.timeEnd("[deleteQuestionsFromCSV] Papa.unparse+writeFileSync");
+
+    console.log(`[deleteQuestionsFromCSV] ${ids.length}개 삭제 완료`);
+    return { success: true };
+  } catch (error) {
+    console.error('deleteQuestionsFromCSV error:', error);
     return { success: false, message: error.message };
   }
 }

--- a/src/controllers/questionController.js
+++ b/src/controllers/questionController.js
@@ -25,12 +25,18 @@ export function readQuestionsCSV() {
       return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
     }
 
+    console.time("[readQuestionsCSV] total (Main)");
+
+    console.time("[readQuestionsCSV] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
+    console.timeEnd("[readQuestionsCSV] readFileSync");
+
     let questions = [];
     const tagSet = new Set();
 
+    console.time("[readQuestionsCSV] Papa.parse+map");
     Papa.parse(csvFile, {
-      header: true, 
+      header: true,
       skipEmptyLines: true,
       complete: (result) => {
         questions = result.data.map((item) => {
@@ -38,15 +44,17 @@ export function readQuestionsCSV() {
           if (item.tag) item.tag = item.tag.split(',').map(t => t.trim());
           else item.tag = [];
 
-          item.tag.forEach(t => tagSet.add(t)); // 태그 집합에 추가
+          item.tag.forEach(t => tagSet.add(t));
 
           item.id = generateUniqueId();
           item.checked = false;
           return item;
         });
+        console.timeEnd("[readQuestionsCSV] Papa.parse+map");
       },
     });
 
+    console.timeEnd("[readQuestionsCSV] total (Main)");
     console.log("questions read success");
 
     return {
@@ -74,12 +82,20 @@ export function updateRecommendDates() {
       return { success: false, message: 'CSV 파일을 찾을 수 없습니다.' };
     }
 
+    console.time("[updateRecommendDates] total (Main)");
+
+    console.time("[updateRecommendDates] readFileSync");
     const csvFile = readFileSync(questionsCsvPath, 'utf-8');
+    console.timeEnd("[updateRecommendDates] readFileSync");
+
+    console.time("[updateRecommendDates] Papa.parse");
     const parsed = Papa.parse(csvFile, { header: true, skipEmptyLines: true });
+    console.timeEnd("[updateRecommendDates] Papa.parse");
 
     const today = getTodayDate();
     const todayDate = parseISO(today);
 
+    console.time("[updateRecommendDates] map");
     const updatedData = parsed.data.map(row => {
       const recommendDate = parseISO(row.recommenddate);
       const updateDate = parseISO(row.update);
@@ -98,10 +114,14 @@ export function updateRecommendDates() {
 
       return row;
     });
+    console.timeEnd("[updateRecommendDates] map");
 
+    console.time("[updateRecommendDates] Papa.unparse+writeFileSync");
     const newCsv = Papa.unparse(updatedData);
     writeFileSync(questionsCsvPath, newCsv, 'utf-8');
+    console.timeEnd("[updateRecommendDates] Papa.unparse+writeFileSync");
 
+    console.timeEnd("[updateRecommendDates] total (Main)");
     console.log('recommenddate update success');
     return { success: true, message: 'recommenddate가 성공적으로 업데이트되었습니다.' };
   } catch (error) {
@@ -120,6 +140,7 @@ export function updateQuestionsFile(questions) {
   console.log("updateQuestionsFile called!");
 
   try {
+    console.time("[updateQuestionsFile] Papa.unparse+writeFileSync");
     const csvString = Papa.unparse(
       questions.map(question => {
         const { id, checked, ...rest } = question;
@@ -127,9 +148,23 @@ export function updateQuestionsFile(questions) {
       })
     );
     writeFileSync(questionsCsvPath, csvString, 'utf-8');
+    console.timeEnd("[updateQuestionsFile] Papa.unparse+writeFileSync");
     return { success: true };
   } catch (error) {
     console.error('CSV update error:', error);
+    return { success: false, message: error.message };
+  }
+}
+
+export function writeQuestionsCSVFile(csv) {
+  console.log("writeQuestionsCSVFile called!");
+  try {
+    console.time("[writeQuestionsCSVFile] writeFileSync");
+    writeFileSync(questionsCsvPath, csv, 'utf-8');
+    console.timeEnd("[writeQuestionsCSVFile] writeFileSync");
+    return { success: true };
+  } catch (error) {
+    console.error('CSV write error:', error);
     return { success: false, message: error.message };
   }
 }

--- a/src/handlers/ipcHandlers.js
+++ b/src/handlers/ipcHandlers.js
@@ -7,7 +7,7 @@
 
 import { ipcMain, dialog, app } from 'electron';
 import { getMainWindow } from '../services/windowService.js';
-import { readQuestionsCSV, updateRecommendDates, updateQuestionsFile, writeQuestionsCSVFile } from '../controllers/questionController.js';
+import { initQuestions, readQuestionsCSV, updateRecommendDates, updateQuestionsFile, writeQuestionsCSVFile, appendQuestionToCSV, updateQuestionInCSV, deleteQuestionsFromCSV } from '../controllers/questionController.js';
 import { updateHistory, readHistoryCSV } from '../controllers/historyController.js';
 import { saveImage, deleteImage, exportQuestions, extractZip } from '../controllers/fileController.js';
 import { userDataPath } from '../config/paths.js';
@@ -22,10 +22,14 @@ function setupIpcHandlers() {
     console.log("setupIpcHandlers called!");
 
     // 질문 관련 핸들러
+    ipcMain.handle('init-questions', () => initQuestions());
     ipcMain.handle('read-questions-csv', () => readQuestionsCSV());
     ipcMain.handle('update-recommend-dates', () => updateRecommendDates());
     ipcMain.handle('update-questions-file', (event, questions) => updateQuestionsFile(questions));
     ipcMain.handle('write-questions-csv', (event, csv) => writeQuestionsCSVFile(csv));
+    ipcMain.handle('append-question', (event, question) => appendQuestionToCSV(question));
+    ipcMain.handle('update-question', (event, question) => updateQuestionInCSV(question));
+    ipcMain.handle('delete-questions', (event, ids) => deleteQuestionsFromCSV(ids));
 
     // 기록 관련 핸들러
     ipcMain.handle('read-history-csv', () => readHistoryCSV());

--- a/src/handlers/ipcHandlers.js
+++ b/src/handlers/ipcHandlers.js
@@ -7,7 +7,7 @@
 
 import { ipcMain, dialog, app } from 'electron';
 import { getMainWindow } from '../services/windowService.js';
-import { readQuestionsCSV, updateRecommendDates, updateQuestionsFile } from '../controllers/questionController.js';
+import { readQuestionsCSV, updateRecommendDates, updateQuestionsFile, writeQuestionsCSVFile } from '../controllers/questionController.js';
 import { updateHistory, readHistoryCSV } from '../controllers/historyController.js';
 import { saveImage, deleteImage, exportQuestions, extractZip } from '../controllers/fileController.js';
 import { userDataPath } from '../config/paths.js';
@@ -25,6 +25,7 @@ function setupIpcHandlers() {
     ipcMain.handle('read-questions-csv', () => readQuestionsCSV());
     ipcMain.handle('update-recommend-dates', () => updateRecommendDates());
     ipcMain.handle('update-questions-file', (event, questions) => updateQuestionsFile(questions));
+    ipcMain.handle('write-questions-csv', (event, csv) => writeQuestionsCSVFile(csv));
 
     // 기록 관련 핸들러
     ipcMain.handle('read-history-csv', () => readHistoryCSV());

--- a/src/handlers/ipcHandlers.js
+++ b/src/handlers/ipcHandlers.js
@@ -19,8 +19,6 @@ import { getUserId } from '../services/settingService.js';
  * 이 함수는 애플리케이션에서 사용자가 요청할 수 있는 여러 가지 작업을 처리하는 IPC 핸들러들을 설정합니다.
  */
 function setupIpcHandlers() {
-    console.log("setupIpcHandlers called!");
-
     // 질문 관련 핸들러
     ipcMain.handle('init-questions', () => initQuestions());
     ipcMain.handle('read-questions-csv', () => readQuestionsCSV());

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { app, shell } from 'electron';
+import { app, shell, Menu } from 'electron';
 import { createWindow, getMainWindow, applyNavigationPolicy } from './services/windowService.js';
 import { setupAutoUpdater } from './services/updateService.js';
 import { setupIpcHandlers } from './handlers/ipcHandlers.js';
@@ -8,6 +8,9 @@ import { trackEvent } from "./services/gaService.js";
 
 
 dotenv.config();
+
+// macOS 앱 메뉴 제거 (app ready 이전에 호출)
+Menu.setApplicationMenu(null);
 
 // IPC 핸들러 설정
 setupIpcHandlers();

--- a/src/pages/dashboard/Dashboard.js
+++ b/src/pages/dashboard/Dashboard.js
@@ -63,9 +63,7 @@ const Dashboard = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
-        console.time("[dashboard] readHistoryCSV");
         const historyResult = await window.electronAPI.readHistoryCSV();
-        console.timeEnd("[dashboard] readHistoryCSV");
         if (historyResult.success) {
           setHistoryData(historyResult.historyData);
         } else {
@@ -103,8 +101,6 @@ const Dashboard = () => {
 
     setRecommendedQuestions(filtered);
     setSolvedCount(solved);
-    console.log("Filtered Questions:", filtered);
-    console.log("Solved Count:", solved);
   }, [questions, today]);
 
   // 오늘 풀어야 할 문제들 리스트 정의
@@ -123,7 +119,6 @@ const Dashboard = () => {
 
     setTodayProblemsToSolve(filtered);
     setToSolveCount(filtered.length);
-    console.log("todayProblemsToSolve:", filtered);
   }, [recommendedQuestions, today, questions]);
 
   // 차트 데이터 상태 관리: 최근 30개의 기록만 표시
@@ -182,7 +177,6 @@ const Dashboard = () => {
 
   // 총 추천 문제 수, 총 문제 수, 완료 퍼센트 계산
   const totalRecommendToday = useMemo(() => toSolveCount + solvedCount, [toSolveCount, solvedCount]);
-  console.log("toSolveCount:", toSolveCount, "solvedCount:", solvedCount);
 
   const totalProblems = useMemo(() => totalRecommendToday, [totalRecommendToday]);
   const completedProblems = useMemo(() => solvedCount, [solvedCount]);
@@ -210,8 +204,6 @@ const Dashboard = () => {
 
   // 문제풀기 버튼 클릭 핸들러
   const handleSolveProblems = () => {
-    console.log(`풀 문제 수: ${selectedProblemCount}`);
-    // 문제풀기 로직 또는 navigate 호출
   };
 
   if (loadingHistory || loadingRecommendations) {

--- a/src/pages/dashboard/Dashboard.js
+++ b/src/pages/dashboard/Dashboard.js
@@ -63,7 +63,9 @@ const Dashboard = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
+        console.time("[dashboard] readHistoryCSV");
         const historyResult = await window.electronAPI.readHistoryCSV();
+        console.timeEnd("[dashboard] readHistoryCSV");
         if (historyResult.success) {
           setHistoryData(historyResult.historyData);
         } else {

--- a/src/pages/loading/InitLoading.js
+++ b/src/pages/loading/InitLoading.js
@@ -2,20 +2,14 @@ import React, {useEffect, useState } from "react";
 
 const stepMessageMap = {
     idle: "문제어때가 시작을 준비하고 있어요",
-    "loading-settings": "설정을 확인하고 있어요",
-    "loading-questions": "문제들을 불러오고 있어요",
-    "recommendations": "오늘의 추천 문제를 준비하고 있어요",
-    "loading-updateQuestions": "마무리로 데이터를 정리하고 있어요",
+    "loading": "문제들을 불러오고 있어요",
     "ready": "준비가 끝났어요. 곧 시작합니다!",
     "error": "앗, 준비 중에 잠시 문제가 생겼어요",
 };
 
 const stepProgressMap = {
     idle: 10,
-    "loading-settings": 15,
-    "loading-questions": 45,
-    "recommendations": 60,
-    "loading-updateQuestions": 85,
+    "loading": 50,
     ready: 100,
     error: 100,
 };

--- a/src/pages/question/QuestionItem.js
+++ b/src/pages/question/QuestionItem.js
@@ -1,16 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useRecoilValue } from "recoil";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import { appPathAtom } from "state/data.js";
 import { markdownComponents } from "utils/markdownUtils.js";
 
-function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
+function QuestionItem({ question, index, isChecked, onUpdateClick, handleCheckboxChange }) {
   const appPath = useRecoilValue(appPathAtom);
   const tags = question.tag || [];
-  const tag = tags.map((tagName, index) => (
+  const tag = tags.map((tagName, i) => (
     <span
-      key={index}
+      key={i}
       className="font-medium text-xs whitespace-nowrap bg-gray-300 rounded-xl py-1 px-2"
     >
       {tagName}
@@ -18,35 +18,19 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
   ));
 
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const toggle = () => {
-    setIsCollapsed((state) => !state);
-  };
+  const toggle = () => setIsCollapsed(s => !s);
 
-  const [isChecked, setIsChecked] = useState(question.checked || false); // 기본값 설정
   const [noAnim, setNoAnim] = useState(false);
-  
-  useEffect(() => {
-    setIsChecked(question.checked);
-  }, [question]);
 
   const updateClick = (event) => {
     event.stopPropagation();
-    onUpdateClick();
+    onUpdateClick(question, index);
   };
-
-  
-
 
   const onChangeCheckbox = (e) => {
     e.stopPropagation();
-    const next = e.target.checked;
-
-    // 1) 체크 순간 즉시 반영
     setNoAnim(true);
-    setIsChecked(next);
-    handleCheckboxChange(e); // 기존 부모 통지 로직 그대로
-
-    // 2) 한/두 프레임 뒤에 원복 (hover 애니메이션 유지)
+    handleCheckboxChange(question.id);
     requestAnimationFrame(() => {
       requestAnimationFrame(() => setNoAnim(false));
     });
@@ -56,23 +40,16 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
   const openModal = () => setShowModal(true);
   const closeModal = () => setShowModal(false);
 
-  const Modal = ({ imgSrc, onClose }) => {
-    return (
-      <div
-        onClick={onClose}
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
-      >
-        <div className="relative">
-          <img
-            src={imgSrc}
-            alt="Preview"
-            onClick={onClose}
-            className="max-h-[80vh] max-w-[80vw] rounded"
-          />
-        </div>
+  const Modal = ({ imgSrc, onClose }) => (
+    <div
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    >
+      <div className="relative">
+        <img src={imgSrc} alt="Preview" onClick={onClose} className="max-h-[80vh] max-w-[80vw] rounded" />
       </div>
-    );
-  };
+    </div>
+  );
 
   const UpdateIconWithTooltip = () => (
     <div className="flex items-center">
@@ -80,73 +57,58 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
         onClick={(e) => updateClick(e)}
         className="cursor-pointer rounded-xl hover:font-bold hover:bg-gray-100 w-max text-xs text-blue-600 p-2"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth="1.5"
-          stroke="currentColor"
-          className="size-4"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
-          />
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-4">
+          <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
         </svg>
       </div>
     </div>
   );
 
+  const rowClass = `
+    ${!isCollapsed ? "border-b" : ""}
+    ${!isCollapsed ? "hover:shadow" : ""}
+    ${isChecked ? "bg-gray-200" : ""}
+    transition-all hover:duration-200
+    ${noAnim ? "!duration-0" : ""}
+  `;
+
+  const expandedRowClass = `
+    ${isChecked ? "bg-gray-200" : ""}
+    ${isCollapsed ? "border-b" : ""}
+    transition-all hover:shadow hover:duration-500
+    ${noAnim ? "!duration-0" : ""}
+  `;
+
   if (question.type === "주관식") {
     return (
       <>
-        <tr
-          onClick={toggle}
-          className={`
-          ${!isCollapsed ? "border-b" : ""}
-          ${!isCollapsed ? "hover:shadow" : ""}
-          ${isChecked ? "bg-gray-200" : ""}
-          transition-all hover:duration-200
-          ${noAnim ? "!duration-0" : ""}
-      `}
-        >
+        <tr onClick={toggle} className={rowClass}>
           <td className="w-4 p-4 align-top py-4 px-8">
-            <div className="flex items-center ">
+            <div className="flex items-center">
               <input
-                id="checkbox-table-search-1"
                 type="checkbox"
-                checked={!!isChecked} // boolean
+                checked={!!isChecked}
                 onChange={onChangeCheckbox}
                 onClick={(e) => e.stopPropagation()}
                 className="w-4 h-4 text-blue-600 cursor-pointer bg-gray-100 rounded focus:ring-blue-500 focus:ring-2"
               />
             </div>
           </td>
-          <td className="flex items-center px-6 py-4 text-gray-900 ">
+          <td className="flex items-center px-6 py-4 text-gray-900">
             <div className="flex-1">
               <div className="text-base font-bold">{question.title}</div>
               <div className="flex gap-1 mt-2">{tag}</div>
             </div>
           </td>
-          <td className="hidden px-6 py-4 align-top">
-            <div className="flex gap-1">{tag}</div>
+          <td className="hidden px-6 py-4 align-top"><div className="flex gap-1">{tag}</div></td>
+          <td className="px-6 py-4 align-top">
+            <div className="font-medium text-sm whitespace-nowrap">{question.type}</div>
           </td>
-          <td className="px-6 py-4 align-top ">
-            <div className="font-medium text-sm whitespace-nowrap">
-              {question.type}
-            </div>
-          </td>
-          <td className="px-3 py-2 align-top">
-            <UpdateIconWithTooltip />
-          </td>
+          <td className="px-3 py-2 align-top"><UpdateIconWithTooltip /></td>
           <td className="px-3 py-2 align-top">
             {question.description && (
               <div className="relative group ml-1">
-                <img
-                  src="./images/light_icon.png"
-                  className="w-5 h-5 cursor-pointer hover:scale-110 transition-all text hover:scale-110 mr-1"
-                />
+                <img src="./images/light_icon.png" className="w-5 h-5 cursor-pointer hover:scale-110 transition-all mr-1" />
                 <div className="absolute top-full left-0 transform -translate-x-1/2 mb-2 hidden group-hover:block bg-black text-white text-xs rounded py-1 px-2 w-[100px] max-h-[200px] overflow-y-auto text-wrap opacity-50 z-10">
                   {question.description}
                 </div>
@@ -154,111 +116,62 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
             )}
           </td>
         </tr>
-        <tr
-          className={`
-            ${isChecked ? "bg-gray-200" : ""}
-            ${isCollapsed ? "border-b" : ""}
-            transition-all hover:shadow hover:duration-500
-            ${noAnim ? "!duration-0" : ""}
-          `}
-        >
+        <tr className={expandedRowClass}>
           <td></td>
           <td className="overflow-hidden">
-            <div
-              className={`flex transition-all duration-500 ease-in-out ${
-                isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
-              }`}
-            >
+            <div className={`flex transition-all duration-500 ease-in-out ${isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"}`}>
               <div className="flex-1 font-normal text-sm text-gray-500 flex flex-col px-6 pb-3 gap-2 max-h-60 overflow-y-auto">
                 <div className="border bg-white rounded-lg p-2.5 px-4">
-                  <ReactMarkdown
-                    components={markdownComponents}
-                    remarkPlugins={[remarkBreaks]}
-                  >
-                    {question.answer}
-                  </ReactMarkdown>
+                  <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkBreaks]}>{question.answer}</ReactMarkdown>
                 </div>
               </div>
             </div>
           </td>
           <td colSpan={2} className="overflow-hidden">
-            <div
-              className={`flex transition-all duration-500 ease-in-out ${
-                isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
-              }`}
-            >
+            <div className={`flex transition-all duration-500 ease-in-out ${isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"}`}>
               {question.img && (
                 <div className="p-5 px-6">
-                  <img
-                    src={appPath + question.img}
-                    onClick={openModal}
-                    className="rounded aspect-video min-w-[10vw] max-w-[20vw]"
-                    alt="미리보기"
-                  />
+                  <img src={appPath + question.img} onClick={openModal} className="rounded aspect-video min-w-[10vw] max-w-[20vw]" alt="미리보기" />
                 </div>
               )}
             </div>
           </td>
-          <td className="p-0 align-top">
-          </td>
+          <td className="p-0 align-top"></td>
         </tr>
-        {showModal && (
-          <Modal imgSrc={appPath + question.img} onClose={closeModal} />
-        )}
+        {showModal && <Modal imgSrc={appPath + question.img} onClose={closeModal} />}
       </>
     );
   }
 
   return (
     <>
-      <tr
-          onClick={toggle}
-          className={`
-          ${!isCollapsed ? "border-b" : ""}
-          ${!isCollapsed ? "hover:shadow" : ""}
-          ${isChecked ? "bg-gray-200" : ""}
-          transition-all hover:duration-200
-          ${noAnim ? "!duration-0" : ""}
-      `}
-      >
+      <tr onClick={toggle} className={rowClass}>
         <td className="w-4 p-4 align-top py-4 px-8">
-          <div className="flex items-center ">
+          <div className="flex items-center">
             <input
-              id="checkbox-table-search-1"
               type="checkbox"
-              checked={isChecked}
-              onChange={handleCheckboxChange}
+              checked={!!isChecked}
+              onChange={onChangeCheckbox}
               onClick={(e) => e.stopPropagation()}
               className="cursor-pointer w-4 h-4 text-blue-600 bg-gray-100 rounded focus:ring-blue-500 focus:ring-2"
             />
           </div>
         </td>
-        <td className="flex items-center px-6 py-4 text-gray-900 ">
+        <td className="flex items-center px-6 py-4 text-gray-900">
           <div className="flex-1">
             <div className="text-base font-bold">{question.title}</div>
             <div className="flex gap-1 mt-2">{tag}</div>
           </div>
         </td>
-        <td className="hidden px-6 py-4 align-top">
-          <div className="flex gap-1">{tag}</div>
+        <td className="hidden px-6 py-4 align-top"><div className="flex gap-1">{tag}</div></td>
+        <td className="px-6 py-4 align-top">
+          <div className="font-medium text-sm whitespace-nowrap">{question.type}</div>
         </td>
-        <td className="px-6 py-4 align-top ">
-          <div className="font-medium text-sm whitespace-nowrap">
-            {question.type}
-          </div>
-        </td>
-        <td className="px-3 py-2 align-top">
-          <div>
-            <UpdateIconWithTooltip />
-          </div>
-        </td>
+        <td className="px-3 py-2 align-top"><UpdateIconWithTooltip /></td>
         <td className="px-3 py-2 align-top">
           {question.description && (
             <div className="relative group ml-1">
-              <img
-                src="./images/light_icon.png"
-                className="w-5 h-5 cursor-pointer hover:scale-110 transition-all text hover:scale-110 mr-1"
-              />
+              <img src="./images/light_icon.png" className="w-5 h-5 cursor-pointer hover:scale-110 transition-all mr-1" />
               <div className="absolute top-full left-0 transform -translate-x-1/2 mb-2 hidden group-hover:block bg-black text-white text-xs rounded py-1 px-2 w-[100px] max-h-[200px] overflow-y-auto text-wrap opacity-50 z-10">
                 {question.description}
               </div>
@@ -266,114 +179,48 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
           )}
         </td>
       </tr>
-       <tr
-          className={`
-            ${isChecked ? "bg-gray-200" : ""}
-            ${isCollapsed ? "border-b" : ""}
-            transition-all hover:shadow hover:duration-500
-            ${noAnim ? "!duration-0" : ""}
-          `}
-        >
+      <tr className={expandedRowClass}>
         <td></td>
         <td className="overflow-hidden">
-          <div
-            className={`flex transition-all duration-500 ease-in-out ${
-              isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
-            }`}
-          >
+          <div className={`flex transition-all duration-500 ease-in-out ${isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"}`}>
             <div className="flex-1 font-normal text-sm text-gray-500 flex flex-col px-6 pb-3 gap-2 max-h-60 overflow-y-auto">
               {question.select1 && (
-                <div
-                  className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${
-                    question.select1 === question.answer
-                      ? "font-bold text-blue-500"
-                      : ""
-                  }`}
-                >
-                  <ReactMarkdown
-                    components={markdownComponents}
-                    remarkPlugins={[remarkBreaks]}
-                  >
-                    {question.select1}
-                  </ReactMarkdown>
+                <div className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${question.select1 === question.answer ? "font-bold text-blue-500" : ""}`}>
+                  <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkBreaks]}>{question.select1}</ReactMarkdown>
                 </div>
               )}
               {question.select2 && (
-                <div
-                  className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${
-                    question.select2 === question.answer
-                      ? "font-bold text-blue-500"
-                      : ""
-                  }`}
-                >
-                  <ReactMarkdown
-                    components={markdownComponents}
-                    remarkPlugins={[remarkBreaks]}
-                  >
-                    {question.select2}
-                  </ReactMarkdown>
+                <div className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${question.select2 === question.answer ? "font-bold text-blue-500" : ""}`}>
+                  <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkBreaks]}>{question.select2}</ReactMarkdown>
                 </div>
               )}
               {question.select3 && (
-                <div
-                  className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${
-                    question.select3 === question.answer
-                      ? "font-bold text-blue-500"
-                      : ""
-                  }`}
-                >
-                  <ReactMarkdown
-                    components={markdownComponents}
-                    remarkPlugins={[remarkBreaks]}
-                  >
-                    {question.select3}
-                  </ReactMarkdown>
+                <div className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${question.select3 === question.answer ? "font-bold text-blue-500" : ""}`}>
+                  <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkBreaks]}>{question.select3}</ReactMarkdown>
                 </div>
               )}
               {question.select4 && (
-                <div
-                  className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${
-                    question.select4 === question.answer
-                      ? "font-bold text-blue-500"
-                      : ""
-                  }`}
-                >
-                  <ReactMarkdown
-                    components={markdownComponents}
-                    remarkPlugins={[remarkBreaks]}
-                  >
-                    {question.select4}
-                  </ReactMarkdown>
+                <div className={`border bg-white rounded-lg p-2.5 px-4 whitespace-pre-wrap ${question.select4 === question.answer ? "font-bold text-blue-500" : ""}`}>
+                  <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkBreaks]}>{question.select4}</ReactMarkdown>
                 </div>
               )}
             </div>
           </div>
         </td>
         <td colSpan={2} className="overflow-hidden">
-          <div
-            className={`flex transition-all duration-500 ease-in-out ${
-              isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
-            }`}
-          >
+          <div className={`flex transition-all duration-500 ease-in-out ${isCollapsed ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"}`}>
             {question.img && (
               <div className="p-5 px-6">
-                <img
-                  src={appPath + question.img}
-                  onClick={openModal}
-                  className="rounded aspect-video min-w-[10vw] max-w-[20vw] cursor-pointer"
-                  alt="미리보기"
-                />
+                <img src={appPath + question.img} onClick={openModal} className="rounded aspect-video min-w-[10vw] max-w-[20vw] cursor-pointer" alt="미리보기" />
               </div>
             )}
           </div>
         </td>
         <td className="p-0 align-top"></td>
       </tr>
-      {showModal && (
-        <Modal imgSrc={appPath + question.img} onClose={closeModal} />
-      )}
+      {showModal && <Modal imgSrc={appPath + question.img} onClose={closeModal} />}
     </>
   );
 }
 
-export default QuestionItem;
+export default React.memo(QuestionItem);

--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocation } from "react-router-dom";
@@ -22,6 +22,14 @@ function Questions() {
   //존재하는 중복 없는 모든 태그
   const allTag = useRecoilValue(allTagAtom);
   const [selectedTag, setSelectedTag] = useState([]);
+
+  // 선택 시스템
+  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [isAllSelected, setIsAllSelected] = useState(false);
+  const [excludedIds, setExcludedIds] = useState(new Set());
+
+  // 무한 스크롤
+  const [displayCount, setDisplayCount] = useState(50);
 
   useEffect(() => {
     if (location.state?.openModal) {
@@ -47,15 +55,58 @@ function Questions() {
     };
   }, []);
 
+  // selectedTag 변경 시 displayCount 리셋
+  useEffect(() => {
+    setDisplayCount(50);
+  }, [selectedTag]);
+
   // 태그 선택/해제 핸들러
   const onTagClick = (tagName) => {
     setSelectedTag(
       (prev) =>
         prev.includes(tagName)
-          ? prev.filter((tag) => tag !== tagName) // 이미 선택된 경우 제거
-          : [...prev, tagName] // 새로 선택된 경우 추가
+          ? prev.filter((tag) => tag !== tagName)
+          : [...prev, tagName]
     );
   };
+
+  const handleCheckboxChange = useCallback((id) => {
+    if (isAllSelected) {
+      setExcludedIds(prev => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      });
+    } else {
+      setCheckedIds(prev => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      });
+    }
+  }, [isAllSelected]);
+
+  const handleAllCheckboxChange = useCallback(() => {
+    setCheckedIds(new Set());
+    setExcludedIds(new Set());
+    setIsAllSelected(prev => !prev);
+  }, []);
+
+  const handleLoadMore = useCallback(() => {
+    setDisplayCount(prev => prev + 50);
+  }, []);
+
+  const onQuestionAdded = useCallback((newId) => {
+    if (isAllSelected) {
+      setExcludedIds(prev => new Set([...prev, newId]));
+    }
+  }, [isAllSelected]);
+
+  const onQuestionsAdded = useCallback((newIds) => {
+    if (isAllSelected && newIds.length > 0) {
+      setExcludedIds(prev => new Set([...prev, ...newIds]));
+    }
+  }, [isAllSelected]);
 
   // questions 변경 시작 시점 기록
   useEffect(() => {
@@ -115,33 +166,29 @@ function Questions() {
   const [updateQuestion, setUpdateQuestion] = useState(null); // 수정할 질문 객체 (모달 제어 포함)
   const [updateIndex, setUpdateIndex] = useState(null);
 
-  const handleUpdateClick = (question, index) => {
+  const handleUpdateClick = useCallback((question, index) => {
     setInsertModal(false);
     setUpdateModal(true);
     setUpdateIndex(index);
     setUpdateQuestion({ ...question });
-  };
+  }, []);
 
-  /**
- * 질문 목록 중 checked == true인 항목이 있으면 → 체크된 질문만 추출해서 checked, id 제거 후 반환
- * checked == true인 항목이 없으면 → 전체 질문을 대상으로 checked, id 제거 후 반환
- */
+  const selectedCount = isAllSelected
+    ? filterQuestions.filter(({ question }) => !excludedIds.has(question.id)).length
+    : filterQuestions.filter(({ question }) => checkedIds.has(question.id)).length;
+
+  const isAllChecked = selectedCount > 0 && selectedCount === filterQuestions.length;
+
   const handleDownloadToZip = async () => {
-    console.log("filterQuestions :", filterQuestions);
-    const downloadQuestions =
-      filterQuestions
-        .some(({ index, question }) => question.checked)
-        ? filterQuestions
-          .filter(({ index, question }) => question.checked) // question.checked가 true인 것만 필터링
-          .map(({ index, question }) => {
-            const { checked, id, ...rest } = question;
-            return rest;
-          })
-        : filterQuestions
-          .map(({ index, question }) => {
-            const { checked, id, ...rest } = question; // checked 제외한 데이터만 추출
-            return rest;
-          });
+    const isSelected = (question) =>
+      isAllSelected ? !excludedIds.has(question.id) : checkedIds.has(question.id);
+
+    const downloadQuestions = selectedCount > 0
+      ? filterQuestions
+          .filter(({ question }) => isSelected(question))
+          .map(({ question }) => { const { checked, id, ...rest } = question; return rest; })
+      : filterQuestions
+          .map(({ question }) => { const { checked, id, ...rest } = question; return rest; });
 
     const result = await window.electronAPI.exportQuestions(downloadQuestions);
 
@@ -200,54 +247,66 @@ function Questions() {
     });
   };
 
+  const isDeletingRef = useRef(false);
+
   const deleteFilteredQuestions = async () => {
+    if (isDeletingRef.current) return;
+
     const confirmed = await confirmDeletion();
     if (!confirmed) return;
-  
-    const deleteImages = [];
-  
-    // 삭제할 문제 id 수집
-    const idsToDelete = filterQuestions
-      .filter(({ question }) => {
-        if (question.checked === true) {
-          if (question.img) deleteImages.push(question.img);
-          return true;
-        }
-        return false;
-      })
-      .map(({ question }) => question.id); // 삭제 대상 id만 추출
-  
-    // 전체 questions 기준으로 삭제 대상 제외
-    const newQuestions = questions
-      .filter((q) => !idsToDelete.includes(q.id))
-      .map((q) => {
-        const { checked, ...rest } = q; // checked 제거
-        return rest;
+
+    if (isDeletingRef.current) return;
+    isDeletingRef.current = true;
+
+    try {
+      const isSelected = (question) =>
+        isAllSelected ? !excludedIds.has(question.id) : checkedIds.has(question.id);
+
+      const deleteImagesSet = new Set();
+      const idsToDelete = filterQuestions
+        .filter(({ question }) => {
+          if (isSelected(question)) {
+            if (question.img) deleteImagesSet.add(question.img);
+            return true;
+          }
+          return false;
+        })
+        .map(({ question }) => question.id);
+
+      if (idsToDelete.length === 0) return;
+
+      const newQuestions = questions.filter((q) => !idsToDelete.includes(q.id));
+      setQuestions(newQuestions);
+      console.time("[questions] deleteQuestions IPC");
+      window.electronAPI.deleteQuestions(idsToDelete).then(() => {
+        console.timeEnd("[questions] deleteQuestions IPC");
       });
-  
-    setQuestions(newQuestions); // Recoil 상태 업데이트 → App.js useEffect가 write 처리
-  
-    // 이미지 삭제
-    const handleDelete = async (imagePath) => {
-      try {
-        const result = await window.electronAPI.deleteImage(imagePath);
-        if (result.success) {
-          console.log("이미지가 성공적으로 삭제되었습니다.");
-        } else {
-          console.error("삭제 실패:", result.message);
+
+      setCheckedIds(new Set());
+      setIsAllSelected(false);
+      setExcludedIds(new Set());
+
+      const handleDelete = async (imagePath) => {
+        try {
+          const result = await window.electronAPI.deleteImage(imagePath);
+          if (result.success) {
+            console.log("이미지가 성공적으로 삭제되었습니다.");
+          } else {
+            console.error("삭제 실패:", result.message);
+          }
+        } catch (error) {
+          console.error("삭제 중 오류 발생:", error);
         }
-      } catch (error) {
-        console.error("삭제 중 오류 발생:", error);
-      }
-    };
-    deleteImages.forEach((img) => {
-      handleDelete(img);
-    });
-  
-    toast.success("선택된 문제가 삭제되었습니다.", {
-      position: "top-center",
-      autoClose: 1000,
-    });
+      };
+      [...deleteImagesSet].forEach((img) => handleDelete(img));
+
+      toast.success("선택된 문제가 삭제됐습니다.", {
+        position: "top-center",
+        autoClose: 1000,
+      });
+    } finally {
+      isDeletingRef.current = false;
+    }
   };
   
 
@@ -290,28 +349,30 @@ function Questions() {
   const navigate = useNavigate();
   const goSelectSolve = () => {
     const toSolveTags = new Set();
-    const toSolveQuestions = 
-      filterQuestions.some(({ question }) => question.checked)
+    const isSelected = (question) =>
+      isAllSelected ? !excludedIds.has(question.id) : checkedIds.has(question.id);
+
+    const toSolveQuestions = selectedCount > 0
       ? filterQuestions
-          .filter(({ question }) => question.checked)
+          .filter(({ question }) => isSelected(question))
           .map(({ question }) => {
-            const { checked, id, tag, ...rest } = question;
+            const { checked, tag, ...rest } = question;
             if (tag) tag.forEach((t) => toSolveTags.add(t));
             return rest;
           })
       : filterQuestions.map(({ question }) => {
-          const { checked, id, tag, ...rest } = question;
+          const { checked, tag, ...rest } = question;
           if (tag) tag.forEach((t) => toSolveTags.add(t));
           return rest;
         });
 
-      navigate("/select", {
-        state: {
-          selectedTags: [...toSolveTags], 
-          selectedQuestions: toSolveQuestions, 
-        },
-      });
-  }
+    navigate("/select", {
+      state: {
+        selectedTags: [...toSolveTags],
+        selectedQuestions: toSolveQuestions,
+      },
+    });
+  };
 
   return (
     <main className="ml-20 flex">
@@ -326,12 +387,21 @@ function Questions() {
       <QuestionsMain
         filterQuestions={filterQuestions}
         isCollapsed={isCollapsed}
-        setFilterQuestions={setFilterQuestions}
         deleteFilteredQuestions={deleteFilteredQuestions}
         insertButtonClick={insertButtonClick}
         handleUpdateClick={handleUpdateClick}
         handleDownloadToZip={handleDownloadToZip}
         goSelectSolve={goSelectSolve}
+        checkedIds={checkedIds}
+        isAllSelected={isAllSelected}
+        excludedIds={excludedIds}
+        selectedCount={selectedCount}
+        handleCheckboxChange={handleCheckboxChange}
+        handleAllCheckboxChange={handleAllCheckboxChange}
+        isAllChecked={isAllChecked}
+        displayCount={displayCount}
+        onLoadMore={handleLoadMore}
+        onQuestionsAdded={onQuestionsAdded}
       />
       {/* 오버레이는 모달이 열려있을 때만 렌더링 */}
       {(insertModal || updateModal) && (
@@ -357,7 +427,11 @@ function Questions() {
           data-tour-id="insert-modal-expend"
         />
         {insertModal && (
-          <InsertModal setInsertModal={setInsertModal} expanded={expanded} />
+          <InsertModal
+            setInsertModal={setInsertModal}
+            expanded={expanded}
+            onQuestionAdded={onQuestionAdded}
+          />
         )}
         {updateModal && (
           <UpdateModal

--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -17,7 +17,6 @@ function Questions() {
   const setQuestions = useSetRecoilState(questionsAtom);
 
   const [filterQuestions, setFilterQuestions] = useState([]);
-  const renderTimerRef = useRef(null);
 
   //존재하는 중복 없는 모든 태그
   const allTag = useRecoilValue(allTagAtom);
@@ -108,19 +107,12 @@ function Questions() {
     }
   }, [isAllSelected]);
 
-  // questions 변경 시작 시점 기록
-  useEffect(() => {
-    renderTimerRef.current = performance.now();
-  }, [questions]);
-
   //태그 필터링 이벤트트
   useEffect(() => {
-    console.time("[questions] filterQuestions (연산)");
     if (selectedTag.length === 0) {
       setFilterQuestions(
         questions.map((question, index) => ({ question, index }))
       );
-      console.timeEnd("[questions] filterQuestions (연산)");
       return;
     }
 
@@ -130,17 +122,7 @@ function Questions() {
         question.tag.some((tag) => selectedTag.includes(tag))
       );
     setFilterQuestions(filtered);
-    console.timeEnd("[questions] filterQuestions (연산)");
   }, [questions, selectedTag]);
-
-  // filterQuestions 세팅 완료 시점 → Recoil 변경부터 여기까지가 렌더 준비 시간
-  useEffect(() => {
-    if (renderTimerRef.current !== null) {
-      const elapsed = performance.now() - renderTimerRef.current;
-      console.log(`[questions] Recoil→filterQuestions 완료: ${elapsed.toFixed(2)}ms (문제 수: ${questions.length}개)`);
-      renderTimerRef.current = null;
-    }
-  }, [filterQuestions]);
 
   useEffect(() => {
     const collapseHandler = () => {
@@ -277,10 +259,7 @@ function Questions() {
 
       const newQuestions = questions.filter((q) => !idsToDelete.includes(q.id));
       setQuestions(newQuestions);
-      console.time("[questions] deleteQuestions IPC");
-      window.electronAPI.deleteQuestions(idsToDelete).then(() => {
-        console.timeEnd("[questions] deleteQuestions IPC");
-      });
+      window.electronAPI.deleteQuestions(idsToDelete);
 
       setCheckedIds(new Set());
       setIsAllSelected(false);
@@ -289,9 +268,7 @@ function Questions() {
       const handleDelete = async (imagePath) => {
         try {
           const result = await window.electronAPI.deleteImage(imagePath);
-          if (result.success) {
-            console.log("이미지가 성공적으로 삭제되었습니다.");
-          } else {
+          if (!result.success) {
             console.error("삭제 실패:", result.message);
           }
         } catch (error) {

--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocation } from "react-router-dom";
@@ -17,6 +17,7 @@ function Questions() {
   const setQuestions = useSetRecoilState(questionsAtom);
 
   const [filterQuestions, setFilterQuestions] = useState([]);
+  const renderTimerRef = useRef(null);
 
   //존재하는 중복 없는 모든 태그
   const allTag = useRecoilValue(allTagAtom);
@@ -56,22 +57,39 @@ function Questions() {
     );
   };
 
+  // questions 변경 시작 시점 기록
+  useEffect(() => {
+    renderTimerRef.current = performance.now();
+  }, [questions]);
+
   //태그 필터링 이벤트트
   useEffect(() => {
+    console.time("[questions] filterQuestions (연산)");
     if (selectedTag.length === 0) {
       setFilterQuestions(
         questions.map((question, index) => ({ question, index }))
       );
+      console.timeEnd("[questions] filterQuestions (연산)");
       return;
     }
 
     const filtered = questions
-      .map((question, index) => ({ question, index })) // 각 질문과 인덱스를 묶음
+      .map((question, index) => ({ question, index }))
       .filter(({ question }) =>
         question.tag.some((tag) => selectedTag.includes(tag))
       );
     setFilterQuestions(filtered);
+    console.timeEnd("[questions] filterQuestions (연산)");
   }, [questions, selectedTag]);
+
+  // filterQuestions 세팅 완료 시점 → Recoil 변경부터 여기까지가 렌더 준비 시간
+  useEffect(() => {
+    if (renderTimerRef.current !== null) {
+      const elapsed = performance.now() - renderTimerRef.current;
+      console.log(`[questions] Recoil→filterQuestions 완료: ${elapsed.toFixed(2)}ms (문제 수: ${questions.length}개)`);
+      renderTimerRef.current = null;
+    }
+  }, [filterQuestions]);
 
   useEffect(() => {
     const collapseHandler = () => {
@@ -207,10 +225,7 @@ function Questions() {
         return rest;
       });
   
-    setQuestions(newQuestions); // Recoil 상태 업데이트
-  
-    // CSV 반영
-    await window.electronAPI.updateQuestions(newQuestions);
+    setQuestions(newQuestions); // Recoil 상태 업데이트 → App.js useEffect가 write 처리
   
     // 이미지 삭제
     const handleDelete = async (imagePath) => {

--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -353,6 +353,12 @@ function Questions() {
 
   return (
     <main className="ml-20 flex">
+      {!isCollapsed && (
+        <div
+          className="fixed inset-0 z-[39]"
+          onClick={() => setIsCollapsed(true)}
+        />
+      )}
         <Sidebar
           isCollapsed={isCollapsed}
           allTag={allTag}

--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -386,7 +386,6 @@ function Questions() {
     
       <QuestionsMain
         filterQuestions={filterQuestions}
-        isCollapsed={isCollapsed}
         deleteFilteredQuestions={deleteFilteredQuestions}
         insertButtonClick={insertButtonClick}
         handleUpdateClick={handleUpdateClick}
@@ -416,8 +415,7 @@ function Questions() {
       {/* 모달 컨테이너는 항상 렌더링, 높이는 상태에 따라 변경 */}
       <div
         data-tour-id="insert-modal-root"
-        className={`transition-all duration-500 width-fill-available shadow-[10px_0px_10px_10px_rgba(0,0,0,0.1)] rounded-t-2xl fixed bottom-0 bg-white ${isCollapsed ? "ml-10" : "ml-80"
-          } z-50`}
+        className="width-fill-available shadow-[10px_0px_10px_10px_rgba(0,0,0,0.1)] rounded-t-2xl fixed bottom-0 bg-white ml-10 z-50"
         style={{ height: insertModal || updateModal ? modalHeight : 0 }}
       >
         {/* 드래그 핸들 (모달 상단 중앙에 위치) */}

--- a/src/pages/question/QuestionsMain.js
+++ b/src/pages/question/QuestionsMain.js
@@ -4,7 +4,7 @@ import { questionsAtom } from "state/data.js";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
 function QuestionsMain({
-  isCollapsed, filterQuestions,
+  filterQuestions,
   insertButtonClick, handleUpdateClick, handleDownloadToZip,
   deleteFilteredQuestions, goSelectSolve,
   // selection system
@@ -25,7 +25,7 @@ function QuestionsMain({
     if (!sentinel) return;
     const observer = new IntersectionObserver(
       ([entry]) => { if (entry.isIntersecting) onLoadMore(); },
-      { threshold: 0 }
+      { threshold: 0, rootMargin: "0px 0px 1000px 0px" }
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
@@ -67,14 +67,14 @@ function QuestionsMain({
 
   return (
     <div
-      className={`mb-[300px] transition-all duration-500 flex-1 sm:rounded-lg bg-white ${isCollapsed ? "ml-10" : "ml-80"}`}
+      className="mb-[300px] flex-1 sm:rounded-lg bg-white ml-10"
     >
       <div className="px-8 py-4 flex justify-between border-b">
         <div>
           <h1 className="text-2xl font-semibold">문제 관리</h1>
           <h1 className="text-md font-normal text-gray-400">
             총 {filterQuestions.length}개
-            {selectedCount > 0 && ` · ${filterQuestions.length}개 중 ${selectedCount}개 선택`}
+            {selectedCount > 0 && ` 중 ${selectedCount}개 선택`}
           </h1>
         </div>
         <div className="flex items-center flex">

--- a/src/pages/question/QuestionsMain.js
+++ b/src/pages/question/QuestionsMain.js
@@ -1,60 +1,44 @@
-import React, { useState } from "react";
+import React, { useRef, useEffect } from "react";
 import QuestionItem from "pages/question/QuestionItem.js";
 import { questionsAtom } from "state/data.js";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
-
-function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, insertButtonClick, handleUpdateClick, handleDownloadToZip, deleteFilteredQuestions, goSelectSolve }) {
-  const [isAllChecked, setIsAllChecked] = useState(false); // 전체 체크박스 상태 관리
+function QuestionsMain({
+  isCollapsed, filterQuestions,
+  insertButtonClick, handleUpdateClick, handleDownloadToZip,
+  deleteFilteredQuestions, goSelectSolve,
+  // selection system
+  checkedIds, isAllSelected, excludedIds, selectedCount,
+  handleCheckboxChange, handleAllCheckboxChange, isAllChecked,
+  // infinite scroll
+  displayCount, onLoadMore,
+  // zip
+  onQuestionsAdded,
+}) {
   const questions = useRecoilValue(questionsAtom);
   const setQuestions = useSetRecoilState(questionsAtom);
 
-  const handleCheckboxChange = (index) => {
-    setFilterQuestions((prevQuestions) => {
-      const updatedQuestions = prevQuestions.map(
-        ({ question, index: idx }) => ({
-          question: {
-            ...question,
-            checked: idx === index ? !question.checked : question.checked, // 해당 index만 변경
-          },
-          index: idx,
-        })
-      );
+  const sentinelRef = useRef(null);
 
-      // 전체 체크박스 상태 업데이트
-      const allChecked = updatedQuestions.every(
-        ({ question }) => question.checked
-      );
-      setIsAllChecked(allChecked);
-
-      return updatedQuestions;
-    });
-  };
-
-  // 전체 체크박스 상태 변경
-  const handleAllCheckboxChange = () => {
-    const newCheckedState = !isAllChecked;
-
-    setFilterQuestions((prevQuestions) =>
-      prevQuestions.map(({ question, index }) => ({
-        question: {
-          ...question,
-          checked: newCheckedState, // 전체 체크박스 상태에 따라 변경
-        },
-        index,
-      }))
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) onLoadMore(); },
+      { threshold: 0 }
     );
-
-    setIsAllChecked(newCheckedState);
-  };
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [onLoadMore]);
 
   const handleZipUpload = async (event) => {
-    const file = event.target.files[0]; // 사용자가 업로드한 파일
+    const file = event.target.files[0];
     if (file) {
       try {
         const result = await window.electronAPI.extractZip(file);
         if (result.success) {
-          setQuestions([...result.questions, ...questions]); // questions 배열 업데이트
+          setQuestions([...result.questions, ...questions]);
+          onQuestionsAdded(result.questions.map(q => q.id));
         }
       } catch (error) {
         console.error("Zip 파일 처리 중 오류:", error);
@@ -63,56 +47,62 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
     event.target.files[0] = null;
   };
 
-  // 테이블 데이터 랜더링
-  const questionsItems = filterQuestions.map(({ question, index }) => (
-    <QuestionItem
-      key={index}
-      question={question}
-      defaultChecked={false}
-      onUpdateClick={() => handleUpdateClick(question, index)} // index 전달
-      handleCheckboxChange={() => handleCheckboxChange(index)}
-    />
-  ));
+  const visibleQuestions = filterQuestions.slice(0, displayCount);
+
+  const questionsItems = visibleQuestions.map(({ question, index }) => {
+    const isChecked = isAllSelected
+      ? !excludedIds.has(question.id)
+      : checkedIds.has(question.id);
+    return (
+      <QuestionItem
+        key={question.id}
+        question={question}
+        index={index}
+        isChecked={isChecked}
+        onUpdateClick={handleUpdateClick}
+        handleCheckboxChange={handleCheckboxChange}
+      />
+    );
+  });
 
   return (
     <div
-      className={`mb-[300px] transition-all duration-500 flex-1 sm:rounded-lg bg-white ${isCollapsed ? "ml-10" : "ml-80"
-        }`}
+      className={`mb-[300px] transition-all duration-500 flex-1 sm:rounded-lg bg-white ${isCollapsed ? "ml-10" : "ml-80"}`}
     >
       <div className="px-8 py-4 flex justify-between border-b">
         <div>
           <h1 className="text-2xl font-semibold">문제 관리</h1>
           <h1 className="text-md font-normal text-gray-400">
-            총 {filterQuestions.length} 문제
+            총 {filterQuestions.length}개
+            {selectedCount > 0 && ` · ${filterQuestions.length}개 중 ${selectedCount}개 선택`}
           </h1>
         </div>
-        <div className="flex items-center flex ">
-            <div className="bg-white items-center flex">
+        <div className="flex items-center flex">
+          <div className="bg-white items-center flex">
+            <div
+              data-tour-id="question-solve-add"
+              className="flex items-center relative w-full"
+            >
               <div
-                    data-tour-id="question-solve-add"
-                    className="flex items-center relative w-full"
+                onClick={() => goSelectSolve()}
+                className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center mr-1 ml-1"
               >
-                <div
-                  onClick={() => goSelectSolve()}
-                  className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center mr-1 ml-1"
-                  
-                >
-                  문제풀러가기
-                </div>          
-                <div
-                  onClick={() => insertButtonClick()}
-                  className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center ml-1 mr-1"
-                  data-tour-id="btn-insert-open"
-                >
-                  문제추가
-                </div>
+                문제풀러가기
+              </div>
+              <div
+                onClick={() => insertButtonClick()}
+                className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center ml-1 mr-1"
+                data-tour-id="btn-insert-open"
+              >
+                문제추가
               </div>
             </div>
+          </div>
 
-            <div
-              data-tour-id="question-upload-download"
-              className="flex items-center ml-2 bg-white"
-            >
+          <div
+            data-tour-id="question-upload-download"
+            className="flex items-center ml-2 bg-white"
+          >
             <div className="bg-blue-500 hover:scale-105 text-white font-semibold rounded-full text-xs h-8 w-8 inline-flex items-center transition justify-center mr-1 ml-1">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -131,7 +121,7 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
                 type="file"
                 accept=".zip"
                 className="opacity-0 h-full w-full"
-              ></input>
+              />
             </div>
 
             <div
@@ -185,8 +175,8 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
               <div className="flex items-center">
                 <input
                   type="checkbox"
-                  onChange={handleAllCheckboxChange} // 클릭 시 전체 선택/해제
-                  checked={isAllChecked} // 모든 항목이 체크된 상태에 따라 체크박스 상태 변경
+                  onChange={handleAllCheckboxChange}
+                  checked={isAllChecked}
                   className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2"
                 />
               </div>
@@ -194,7 +184,6 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
             <th scope="col" className="px-6 py-3 w-full">
               문제
             </th>
-
             <th scope="col" className="px-6 py-3 whitespace-nowrap">
               유형
             </th>
@@ -207,7 +196,7 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
                 viewBox="0 0 24 24"
                 strokeWidth="1.5"
                 stroke="currentColor"
-                className="size-4"
+                className="size-4 cursor-pointer"
               >
                 <path
                   strokeLinecap="round"
@@ -221,7 +210,10 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
         <tbody>
           {questionsItems}
           <tr>
-            <td className="rounded-b-xl h-10 bg-gray-50" colSpan={4}></td>
+            <td className="rounded-b-xl h-10 bg-gray-50" colSpan={5}></td>
+          </tr>
+          <tr>
+            <td ref={sentinelRef} colSpan={5} className="h-1"></td>
           </tr>
         </tbody>
       </table>

--- a/src/pages/question/Sidebar.js
+++ b/src/pages/question/Sidebar.js
@@ -1,18 +1,48 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
-/**
- * 사이드바 컴포넌트
- * @param {Object} props - 컴포넌트 속성
- * @param {boolean} props.isCollapsed - 사이드바 접힘 상태
- * @param {Array} props.allTag - 모든 태그 목록
- * @param {Array} props.selectedTag - 선택된 태그 목록
- * @param {Function} props.onTagClick - 태그 클릭 핸들러
- * @returns {JSX.Element} 사이드바 컴포넌트
- */
 function Sidebar({ isCollapsed, allTag, selectedTag, onTagClick, setIsCollapsed }) {
 
+  // 렌더 횟수 추적
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+
+  // 이전 props 추적 (어떤 prop이 바뀌어서 리렌더됐는지)
+  const prevProps = useRef({ isCollapsed, allTag, selectedTag, onTagClick, setIsCollapsed });
+  useEffect(() => {
+    const prev = prevProps.current;
+    const changed = [];
+    if (prev.isCollapsed !== isCollapsed) changed.push(`isCollapsed: ${prev.isCollapsed} → ${isCollapsed}`);
+    if (prev.allTag !== allTag) changed.push(`allTag (ref 변경, 길이: ${prev.allTag.length} → ${allTag.length})`);
+    if (prev.selectedTag !== selectedTag) changed.push(`selectedTag (ref 변경, 길이: ${prev.selectedTag.length} → ${selectedTag.length})`);
+    if (prev.onTagClick !== onTagClick) changed.push(`onTagClick (함수 ref 변경)`);
+    if (prev.setIsCollapsed !== setIsCollapsed) changed.push(`setIsCollapsed (함수 ref 변경)`);
+
+    if (changed.length > 0) {
+      console.log(`[Sidebar] 리렌더 #${renderCount.current} — 변경된 props:`, changed);
+    } else {
+      console.log(`[Sidebar] 리렌더 #${renderCount.current} — props 변경 없음 (부모 리렌더 전파)`);
+    }
+    prevProps.current = { isCollapsed, allTag, selectedTag, onTagClick, setIsCollapsed };
+  });
+
+  // 사이드바 열기/닫기 시 메모리 스냅샷
+  const prevCollapsed = useRef(isCollapsed);
+  useEffect(() => {
+    if (prevCollapsed.current === isCollapsed) return;
+    prevCollapsed.current = isCollapsed;
+
+    const mem = performance.memory;
+    const action = isCollapsed ? "닫힘" : "열림";
+    console.log(`[Sidebar] ${action} — allTag: ${allTag.length}개`);
+    if (mem) {
+      console.log(`[Sidebar] memory — used: ${(mem.usedJSHeapSize / 1024 / 1024).toFixed(1)}MB / total: ${(mem.totalJSHeapSize / 1024 / 1024).toFixed(1)}MB`);
+    }
+  }, [isCollapsed, allTag.length]);
+
+  // allTagItems 계산 시간
+  console.time("[Sidebar] allTagItems 계산");
   const allTagItems = allTag.map((tagName, index) => {
-    const isSelected = selectedTag.includes(tagName); // 선택 여부 확인
+    const isSelected = selectedTag.includes(tagName);
 
     return (
       <div
@@ -25,12 +55,44 @@ function Sidebar({ isCollapsed, allTag, selectedTag, onTagClick, setIsCollapsed 
       </div>
     );
   });
+  console.timeEnd("[Sidebar] allTagItems 계산");
+  console.log(`[Sidebar] allTag: ${allTag.length}개, selectedTag: ${selectedTag.length}개`);
+
+  // 애니메이션 종료 시점 측정
+  const sidebarRef = useRef(null);
+  const animStartTime = useRef(null);
+
+  useEffect(() => {
+    const el = sidebarRef.current;
+    if (!el) return;
+
+    const onTransitionStart = (e) => {
+      if (e.propertyName !== "width") return;
+      animStartTime.current = performance.now();
+    };
+    const onTransitionEnd = (e) => {
+      if (e.propertyName !== "width") return;
+      if (animStartTime.current !== null) {
+        const elapsed = (performance.now() - animStartTime.current).toFixed(1);
+        const state = isCollapsed ? "닫힘" : "열림";
+        console.log(`[Sidebar] 애니메이션 완료 (${state}): ${elapsed}ms`);
+        animStartTime.current = null;
+      }
+    };
+
+    el.addEventListener("transitionstart", onTransitionStart);
+    el.addEventListener("transitionend", onTransitionEnd);
+    return () => {
+      el.removeEventListener("transitionstart", onTransitionStart);
+      el.removeEventListener("transitionend", onTransitionEnd);
+    };
+  }, [isCollapsed]);
 
   return (
     <div
+    ref={sidebarRef}
     data-tour-id="tag-name"
-    className={`fixed h-full ${isCollapsed ? "border-r w-10" : "w-80"
-      } rounded-r-xl  flex flex-col items-center shadow bg-gray-100 transition-all duration-500`}
+    className={`fixed h-full z-40 ${isCollapsed ? "border-r w-10" : "w-80"} rounded-r-xl flex flex-col items-center shadow bg-gray-100 transition-[width] duration-500`}
   >
     <div
       className="cursor-pointer text-gray-400 w-full text-right p-2"

--- a/src/pages/question/Sidebar.js
+++ b/src/pages/question/Sidebar.js
@@ -1,130 +1,53 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 
 function Sidebar({ isCollapsed, allTag, selectedTag, onTagClick, setIsCollapsed }) {
-
-  // 렌더 횟수 추적
-  const renderCount = useRef(0);
-  renderCount.current += 1;
-
-  // 이전 props 추적 (어떤 prop이 바뀌어서 리렌더됐는지)
-  const prevProps = useRef({ isCollapsed, allTag, selectedTag, onTagClick, setIsCollapsed });
-  useEffect(() => {
-    const prev = prevProps.current;
-    const changed = [];
-    if (prev.isCollapsed !== isCollapsed) changed.push(`isCollapsed: ${prev.isCollapsed} → ${isCollapsed}`);
-    if (prev.allTag !== allTag) changed.push(`allTag (ref 변경, 길이: ${prev.allTag.length} → ${allTag.length})`);
-    if (prev.selectedTag !== selectedTag) changed.push(`selectedTag (ref 변경, 길이: ${prev.selectedTag.length} → ${selectedTag.length})`);
-    if (prev.onTagClick !== onTagClick) changed.push(`onTagClick (함수 ref 변경)`);
-    if (prev.setIsCollapsed !== setIsCollapsed) changed.push(`setIsCollapsed (함수 ref 변경)`);
-
-    if (changed.length > 0) {
-      console.log(`[Sidebar] 리렌더 #${renderCount.current} — 변경된 props:`, changed);
-    } else {
-      console.log(`[Sidebar] 리렌더 #${renderCount.current} — props 변경 없음 (부모 리렌더 전파)`);
-    }
-    prevProps.current = { isCollapsed, allTag, selectedTag, onTagClick, setIsCollapsed };
-  });
-
-  // 사이드바 열기/닫기 시 메모리 스냅샷
-  const prevCollapsed = useRef(isCollapsed);
-  useEffect(() => {
-    if (prevCollapsed.current === isCollapsed) return;
-    prevCollapsed.current = isCollapsed;
-
-    const mem = performance.memory;
-    const action = isCollapsed ? "닫힘" : "열림";
-    console.log(`[Sidebar] ${action} — allTag: ${allTag.length}개`);
-    if (mem) {
-      console.log(`[Sidebar] memory — used: ${(mem.usedJSHeapSize / 1024 / 1024).toFixed(1)}MB / total: ${(mem.totalJSHeapSize / 1024 / 1024).toFixed(1)}MB`);
-    }
-  }, [isCollapsed, allTag.length]);
-
-  // allTagItems 계산 시간
-  console.time("[Sidebar] allTagItems 계산");
   const allTagItems = allTag.map((tagName, index) => {
     const isSelected = selectedTag.includes(tagName);
-
     return (
       <div
         onClick={() => onTagClick(tagName)}
         key={index}
-        className={`cursor-pointer transition-transform transform hover:scale-105 whitespace-nowrap py-1 px-2 rounded-xl text-xs font-semibold border-none ${isSelected ? "bg-blue-500 text-white" : "bg-gray-300 text-black"
-          }`}
+        className={`cursor-pointer transition-transform transform hover:scale-105 whitespace-nowrap py-1 px-2 rounded-xl text-xs font-semibold border-none ${isSelected ? "bg-blue-500 text-white" : "bg-gray-300 text-black"}`}
       >
         {tagName}
       </div>
     );
   });
-  console.timeEnd("[Sidebar] allTagItems 계산");
-  console.log(`[Sidebar] allTag: ${allTag.length}개, selectedTag: ${selectedTag.length}개`);
-
-  // 애니메이션 종료 시점 측정
-  const sidebarRef = useRef(null);
-  const animStartTime = useRef(null);
-
-  useEffect(() => {
-    const el = sidebarRef.current;
-    if (!el) return;
-
-    const onTransitionStart = (e) => {
-      if (e.propertyName !== "width") return;
-      animStartTime.current = performance.now();
-    };
-    const onTransitionEnd = (e) => {
-      if (e.propertyName !== "width") return;
-      if (animStartTime.current !== null) {
-        const elapsed = (performance.now() - animStartTime.current).toFixed(1);
-        const state = isCollapsed ? "닫힘" : "열림";
-        console.log(`[Sidebar] 애니메이션 완료 (${state}): ${elapsed}ms`);
-        animStartTime.current = null;
-      }
-    };
-
-    el.addEventListener("transitionstart", onTransitionStart);
-    el.addEventListener("transitionend", onTransitionEnd);
-    return () => {
-      el.removeEventListener("transitionstart", onTransitionStart);
-      el.removeEventListener("transitionend", onTransitionEnd);
-    };
-  }, [isCollapsed]);
 
   return (
     <div
-    ref={sidebarRef}
-    data-tour-id="tag-name"
-    className={`fixed h-full z-40 ${isCollapsed ? "border-r w-10" : "w-80"} rounded-r-xl flex flex-col items-center shadow bg-gray-100 transition-[width] duration-500`}
-  >
-    <div
-      className="cursor-pointer text-gray-400 w-full text-right p-2"
-      onClick={() => setIsCollapsed(!isCollapsed)}
+      data-tour-id="tag-name"
+      className={`fixed h-full z-40 ${isCollapsed ? "border-r w-10" : "w-80"} rounded-r-xl flex flex-col items-center shadow bg-gray-100 transition-[width] duration-500`}
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth={2}
-        stroke="currentColor"
-        className="size-5 inline"
+      <div
+        className="cursor-pointer text-gray-400 w-full text-right p-2"
+        onClick={() => setIsCollapsed(!isCollapsed)}
       >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-        />
-      </svg>
-    </div>
-
-    {!isCollapsed && (
-      <div className="w-full p-5 h-max overflow-auto css-tag-scroll">
-        <div className="font-bold">문제집 선택</div>
-        <div className="flex gap-2 py-2 w-full flex-wrap">
-          {allTagItems}
-        </div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="size-5 inline"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+          />
+        </svg>
       </div>
-    )}
-  </div>
 
-
+      {!isCollapsed && (
+        <div className="w-full p-5 h-max overflow-auto css-tag-scroll">
+          <div className="font-bold">문제집 선택</div>
+          <div className="flex gap-2 py-2 w-full flex-wrap">
+            {allTagItems}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/pages/question/insertModal/InsertModal.js
+++ b/src/pages/question/insertModal/InsertModal.js
@@ -103,12 +103,14 @@ function InsertModal({ setInsertModal, expanded }) {
   }
 
   const insertEvent = async () => {
+    console.time("[insertModal] insertEvent total");
     if (!title) {
       if (!toast.isActive("insert-title-error")) {
         toast.error("제목은 필수 입력 항목입니다", {
           toastId: "insert-title-error",
         });
       }
+      console.timeEnd("[insertModal] insertEvent total");
       return;
     }
 
@@ -153,10 +155,12 @@ function InsertModal({ setInsertModal, expanded }) {
     // 이미지가 있는 경우 처리
     if (imageFile) {
       try {
+        console.time("[insertModal] saveImage");
         const result = await handleSave(
-          question.id, // 질문의 id를 파일명으로 사용
-          imageFile // 파일 내용
+          question.id,
+          imageFile
         );
+        console.timeEnd("[insertModal] saveImage");
 
         if (result.success) {
           question.img = result.path; // 저장된 경로를 할당
@@ -190,6 +194,7 @@ function InsertModal({ setInsertModal, expanded }) {
     setSelectedOptionIndex(null);
     setImageFile(null);
     setQuestions((prevQuestions) => [question, ...prevQuestions]);
+    console.timeEnd("[insertModal] insertEvent total");
 
     if (titleInputRef.current) {
       titleInputRef.current.focus();

--- a/src/pages/question/insertModal/InsertModal.js
+++ b/src/pages/question/insertModal/InsertModal.js
@@ -8,7 +8,7 @@ import InsertModalExpanded from "./InserModalExpanded.js";
 import InsertModalCompact from "./InsertModalCompact.js";
 import { questionsAtom, allTagAtom } from "state/data.js";
 
-function InsertModal({ setInsertModal, expanded }) {
+function InsertModal({ setInsertModal, expanded, onQuestionAdded }) {
   //문제추가폼
   const [title, setTitle] = useState("");
   const [type, setType] = useState("객관식");
@@ -194,6 +194,12 @@ function InsertModal({ setInsertModal, expanded }) {
     setSelectedOptionIndex(null);
     setImageFile(null);
     setQuestions((prevQuestions) => [question, ...prevQuestions]);
+    toast.success("문제가 추가됐습니다.", { position: "top-center", autoClose: 1500 });
+    onQuestionAdded(question.id);
+    console.time("[insertModal] appendQuestion IPC");
+    window.electronAPI.appendQuestion(question).then(() => {
+      console.timeEnd("[insertModal] appendQuestion IPC");
+    });
     console.timeEnd("[insertModal] insertEvent total");
 
     if (titleInputRef.current) {

--- a/src/pages/question/insertModal/InsertModal.js
+++ b/src/pages/question/insertModal/InsertModal.js
@@ -103,14 +103,12 @@ function InsertModal({ setInsertModal, expanded, onQuestionAdded }) {
   }
 
   const insertEvent = async () => {
-    console.time("[insertModal] insertEvent total");
     if (!title) {
       if (!toast.isActive("insert-title-error")) {
         toast.error("제목은 필수 입력 항목입니다", {
           toastId: "insert-title-error",
         });
       }
-      console.timeEnd("[insertModal] insertEvent total");
       return;
     }
 
@@ -155,12 +153,7 @@ function InsertModal({ setInsertModal, expanded, onQuestionAdded }) {
     // 이미지가 있는 경우 처리
     if (imageFile) {
       try {
-        console.time("[insertModal] saveImage");
-        const result = await handleSave(
-          question.id,
-          imageFile
-        );
-        console.timeEnd("[insertModal] saveImage");
+        const result = await handleSave(question.id, imageFile);
 
         if (result.success) {
           question.img = result.path; // 저장된 경로를 할당
@@ -196,11 +189,7 @@ function InsertModal({ setInsertModal, expanded, onQuestionAdded }) {
     setQuestions((prevQuestions) => [question, ...prevQuestions]);
     toast.success("문제가 추가됐습니다.", { position: "top-center", autoClose: 1500 });
     onQuestionAdded(question.id);
-    console.time("[insertModal] appendQuestion IPC");
-    window.electronAPI.appendQuestion(question).then(() => {
-      console.timeEnd("[insertModal] appendQuestion IPC");
-    });
-    console.timeEnd("[insertModal] insertEvent total");
+    window.electronAPI.appendQuestion(question);
 
     if (titleInputRef.current) {
       titleInputRef.current.focus();

--- a/src/pages/question/updateModal/UpdateModal.js
+++ b/src/pages/question/updateModal/UpdateModal.js
@@ -118,12 +118,14 @@ function UpdateModal({
   }
 
   const updateEvent = async () => {
+    console.time("[updateModal] updateEvent total");
     if (!title) {
       if (!toast.isActive("update-title-error")) {
         toast.error("제목은 필수 입력 항목입니다", {
           toastId: "update-title-error",
         });
       }
+      console.timeEnd("[updateModal] updateEvent total");
       return;
     }
 
@@ -183,12 +185,13 @@ function UpdateModal({
     };
 
     if (imageFile) {
-      // 기존 이미지가 있으면 삭제 (삭제에 실패해도 진행할 수 있도록 try-catch)
       if (question.img) {
         try {
+          console.time("[updateModal] deleteImage");
           const deleteResult = await window.electronAPI.deleteImage(
             question.img
           );
+          console.timeEnd("[updateModal] deleteImage");
           if (!deleteResult.success) {
             console.error("기존 이미지 삭제 실패:", deleteResult.message);
             // 삭제 실패 시 추가 처리가 필요하면 여기서 처리
@@ -202,10 +205,11 @@ function UpdateModal({
       const newFileName = generateUniqueId(questions);
 
       try {
+        console.time("[updateModal] saveImage");
         const result = await handleSave(newFileName, imageFile);
+        console.timeEnd("[updateModal] saveImage");
         if (result.success) {
           updatedQuestion.img = result.path;
-          // 이미지 저장 후 파일 상태 초기화
           setImageFile(null);
         } else {
           console.error("이미지 저장 실패:", result.error);
@@ -229,12 +233,12 @@ function UpdateModal({
       updatedQuestion.img = thumbnail
     }
 
-    // 질문 업데이트
     setQuestions((prevQuestions) => {
       const updatedQuestions = [...prevQuestions];
       updatedQuestions[index] = updatedQuestion;
       return updatedQuestions;
     });
+    console.timeEnd("[updateModal] updateEvent total");
 
     setUpdateQuestion(null);
     setUpdateModal(false);

--- a/src/pages/question/updateModal/UpdateModal.js
+++ b/src/pages/question/updateModal/UpdateModal.js
@@ -118,14 +118,12 @@ function UpdateModal({
   }
 
   const updateEvent = async () => {
-    console.time("[updateModal] updateEvent total");
     if (!title) {
       if (!toast.isActive("update-title-error")) {
         toast.error("제목은 필수 입력 항목입니다", {
           toastId: "update-title-error",
         });
       }
-      console.timeEnd("[updateModal] updateEvent total");
       return;
     }
 
@@ -187,11 +185,7 @@ function UpdateModal({
     if (imageFile) {
       if (question.img) {
         try {
-          console.time("[updateModal] deleteImage");
-          const deleteResult = await window.electronAPI.deleteImage(
-            question.img
-          );
-          console.timeEnd("[updateModal] deleteImage");
+          const deleteResult = await window.electronAPI.deleteImage(question.img);
           if (!deleteResult.success) {
             console.error("기존 이미지 삭제 실패:", deleteResult.message);
             // 삭제 실패 시 추가 처리가 필요하면 여기서 처리
@@ -205,9 +199,7 @@ function UpdateModal({
       const newFileName = generateUniqueId(questions);
 
       try {
-        console.time("[updateModal] saveImage");
         const result = await handleSave(newFileName, imageFile);
-        console.timeEnd("[updateModal] saveImage");
         if (result.success) {
           updatedQuestion.img = result.path;
           setImageFile(null);
@@ -238,11 +230,7 @@ function UpdateModal({
       updatedQuestions[index] = updatedQuestion;
       return updatedQuestions;
     });
-    console.time("[updateModal] updateQuestion IPC");
-    window.electronAPI.updateQuestion(updatedQuestion).then(() => {
-      console.timeEnd("[updateModal] updateQuestion IPC");
-    });
-    console.timeEnd("[updateModal] updateEvent total");
+    window.electronAPI.updateQuestion(updatedQuestion);
 
     setUpdateQuestion(null);
     setUpdateModal(false);

--- a/src/pages/question/updateModal/UpdateModal.js
+++ b/src/pages/question/updateModal/UpdateModal.js
@@ -238,6 +238,10 @@ function UpdateModal({
       updatedQuestions[index] = updatedQuestion;
       return updatedQuestions;
     });
+    console.time("[updateModal] updateQuestion IPC");
+    window.electronAPI.updateQuestion(updatedQuestion).then(() => {
+      console.timeEnd("[updateModal] updateQuestion IPC");
+    });
     console.timeEnd("[updateModal] updateEvent total");
 
     setUpdateQuestion(null);

--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -92,6 +92,16 @@ function Card() {
       return updatedQuestions;
     });
 
+    console.time("[card] updateQuestion IPC (correct)");
+    window.electronAPI.updateQuestion({
+      id: currentQuestion.id,
+      level: newLevel.toString(),
+      update: newUpdateDate,
+      solveddate: formattedToday,
+    }).then(() => {
+      console.timeEnd("[card] updateQuestion IPC (correct)");
+    });
+
     // history.csv 업데이트 호출
     try {
       console.time("[card] updateHistory (correct)");
@@ -136,6 +146,16 @@ function Card() {
           : item
       );
       return updatedQuestions;
+    });
+
+    console.time("[card] updateQuestion IPC (wrong)");
+    window.electronAPI.updateQuestion({
+      id: currentQuestion.id,
+      level: newLevel.toString(),
+      update: newUpdateDate,
+      solveddate: formattedToday,
+    }).then(() => {
+      console.timeEnd("[card] updateQuestion IPC (wrong)");
     });
 
     // history.csv 업데이트 호출

--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -92,21 +92,15 @@ function Card() {
       return updatedQuestions;
     });
 
-    console.time("[card] updateQuestion IPC (correct)");
     window.electronAPI.updateQuestion({
       id: currentQuestion.id,
       level: newLevel.toString(),
       update: newUpdateDate,
       solveddate: formattedToday,
-    }).then(() => {
-      console.timeEnd("[card] updateQuestion IPC (correct)");
     });
 
-    // history.csv 업데이트 호출
     try {
-      console.time("[card] updateHistory (correct)");
       const historyResponse = await window.electronAPI.updateHistory({ isCorrect: true });
-      console.timeEnd("[card] updateHistory (correct)");
       if (!historyResponse.success) {
         console.error(historyResponse.message);
       }
@@ -148,21 +142,15 @@ function Card() {
       return updatedQuestions;
     });
 
-    console.time("[card] updateQuestion IPC (wrong)");
     window.electronAPI.updateQuestion({
       id: currentQuestion.id,
       level: newLevel.toString(),
       update: newUpdateDate,
       solveddate: formattedToday,
-    }).then(() => {
-      console.timeEnd("[card] updateQuestion IPC (wrong)");
     });
 
-    // history.csv 업데이트 호출
     try {
-      console.time("[card] updateHistory (wrong)");
       const historyResponse = await window.electronAPI.updateHistory({ isCorrect: false });
-      console.timeEnd("[card] updateHistory (wrong)");
       if (!historyResponse.success) {
         console.error(`history.csv 업데이트 실패: ${historyResponse.message}`);
       }

--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -94,7 +94,9 @@ function Card() {
 
     // history.csv 업데이트 호출
     try {
+      console.time("[card] updateHistory (correct)");
       const historyResponse = await window.electronAPI.updateHistory({ isCorrect: true });
+      console.timeEnd("[card] updateHistory (correct)");
       if (!historyResponse.success) {
         console.error(historyResponse.message);
       }
@@ -138,7 +140,9 @@ function Card() {
 
     // history.csv 업데이트 호출
     try {
+      console.time("[card] updateHistory (wrong)");
       const historyResponse = await window.electronAPI.updateHistory({ isCorrect: false });
+      console.timeEnd("[card] updateHistory (wrong)");
       if (!historyResponse.success) {
         console.error(`history.csv 업데이트 실패: ${historyResponse.message}`);
       }

--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -23,6 +23,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   deleteImage: (imgPath) => ipcRenderer.invoke('delete-image', { imgPath }),
   updateQuestions: (questions) => ipcRenderer.invoke('update-questions-file', questions),
+  writeQuestionsCSV: (csv) => ipcRenderer.invoke('write-questions-csv', csv),
   updateRecommendDates: () => ipcRenderer.invoke('update-recommend-dates'),
   exportQuestions: (questions) => ipcRenderer.invoke("export-questions", questions),
   extractZip: async (file) => {

--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -24,6 +24,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deleteImage: (imgPath) => ipcRenderer.invoke('delete-image', { imgPath }),
   updateQuestions: (questions) => ipcRenderer.invoke('update-questions-file', questions),
   writeQuestionsCSV: (csv) => ipcRenderer.invoke('write-questions-csv', csv),
+  appendQuestion: (question) => ipcRenderer.invoke('append-question', question),
+  updateQuestion: (question) => ipcRenderer.invoke('update-question', question),
+  deleteQuestions: (ids) => ipcRenderer.invoke('delete-questions', ids),
   updateRecommendDates: () => ipcRenderer.invoke('update-recommend-dates'),
   exportQuestions: (questions) => ipcRenderer.invoke("export-questions", questions),
   extractZip: async (file) => {
@@ -43,6 +46,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       reader.readAsArrayBuffer(file);
     });
   },
+  initQuestions: () => ipcRenderer.invoke('init-questions'),
   readQuestionsCSV: () => ipcRenderer.invoke('read-questions-csv'),
   readHistoryCSV: () => ipcRenderer.invoke('read-history-csv'),
   readAppPath:() => ipcRenderer.invoke('read-app-path'),

--- a/src/services/updateService.js
+++ b/src/services/updateService.js
@@ -24,13 +24,9 @@ let progressBar;
 export function setupAutoUpdater(mainWindow) {
   autoUpdater.autoDownload = false;
 
-  autoUpdater.on('checking-for-update', () => {
-    console.log('업데이트 확인 중');
-  });
+  autoUpdater.on('checking-for-update', () => {});
 
   autoUpdater.on('update-available', () => {
-    console.log('업데이트 버전 확인');
-
     dialog.showMessageBox({
       type: 'info',
       title: 'Update',
@@ -44,29 +40,19 @@ export function setupAutoUpdater(mainWindow) {
     });
   });
 
-  autoUpdater.on('update-not-available', () => {
-    console.log('업데이트 없음');
-  });
+  autoUpdater.on('update-not-available', () => {});
 
   autoUpdater.once('download-progress', () => {
-    console.log('설치 중');
-
     progressBar = new ProgressBar({
       text: '다운로드 중입니다...',
     });
 
     progressBar
-      .on('completed', () => {
-        console.log('설치 완료');
-      })
-      .on('aborted', () => {
-        console.log('다운로드 중단');
-      });
+      .on('completed', () => {})
+      .on('aborted', () => {});
   });
 
   autoUpdater.on('update-downloaded', () => {
-    console.log('업데이트 완료');
-
     if (progressBar) {
       progressBar.setCompleted();
     }

--- a/src/services/windowService.js
+++ b/src/services/windowService.js
@@ -29,6 +29,7 @@ export async function createWindow() {
       contextIsolation: true,
       sandbox: true,
       preload: preloadPath,
+      devTools: false,
     },
   });
 

--- a/src/services/windowService.js
+++ b/src/services/windowService.js
@@ -45,10 +45,6 @@ export async function createWindow() {
     mainWindow = null;
   });
 
-  mainWindow.webContents.on('console-message', (_, level, message) => {
-    console.log('[Renderer]', message);
-  });
-
   return mainWindow;
 }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #61 

## 📝 작업 내용
- 문제 리스트를 무한 스크롤 렌더링 방식으로 수정해 리랜더링 과정에서의 스파이크 문제를 해결했습니다.
- `useMemo`를 활용해서 변경 되지 않은 요소들은 리렌더링 방지하여 스파이크 문제를 해결했습니다.
  - 1440개 문제 랜더링 속도 2,637ms → 386ms
-  sideBar 출력 시 문제 리스트 좌우 크기가 변경 되는 과정에서 리랜더링이 발생하여 이 부분을 z-index를 이용해 문제 리스트 리랜더링을 방지했습니다.(transform은 고민햇는데 GPU 사용하는건 너무 과하고 UI 망침)
  - 893 - 989ms → 479 - 501ms (z-index와 transform 둘 다 동일한 결과) 
- 앱 초기화 과정에서 3번의 csv읽기 과정을 1번으로 줄이고 그 과정에서 필요한 update을 완료하도록 수정하였습니다.
  - 461ms  -> 개선 후 193ms
- 이제 csv에 ID 값을 저장합니다.
- 같은 zip 파일 가져오는 경우 이미지 이름 중복으로 인해 덮어 씌우는 문제를 해결했습니다.
- (추가) 앱 초기화 쪽에서 기존 380ms 측정치 외에 개선 전 461ms -> 193ms 

## ✅ 테스트 결과
- [x] 빌드 테스트 완료