### PR TITLE
fix: checkbox selection state independent of active filter

### DIFF
--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -24,8 +24,6 @@ function Questions() {
 
   // 선택 시스템
   const [checkedIds, setCheckedIds] = useState(new Set());
-  const [isAllSelected, setIsAllSelected] = useState(false);
-  const [excludedIds, setExcludedIds] = useState(new Set());
 
   // 무한 스크롤
   const [displayCount, setDisplayCount] = useState(50);
@@ -70,42 +68,28 @@ function Questions() {
   };
 
   const handleCheckboxChange = useCallback((id) => {
-    if (isAllSelected) {
-      setExcludedIds(prev => {
-        const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
-        return next;
-      });
-    } else {
-      setCheckedIds(prev => {
-        const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
-        return next;
-      });
-    }
-  }, [isAllSelected]);
+    setCheckedIds(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }, []);
 
   const handleAllCheckboxChange = useCallback(() => {
-    setCheckedIds(new Set());
-    setExcludedIds(new Set());
-    setIsAllSelected(prev => !prev);
-  }, []);
+    setCheckedIds(prev => {
+      const allChecked = filterQuestions.every(({ question }) => prev.has(question.id));
+      const next = new Set(prev);
+      filterQuestions.forEach(({ question }) => {
+        allChecked ? next.delete(question.id) : next.add(question.id);
+      });
+      return next;
+    });
+  }, [filterQuestions]);
 
   const handleLoadMore = useCallback(() => {
     setDisplayCount(prev => prev + 50);
   }, []);
 
-  const onQuestionAdded = useCallback((newId) => {
-    if (isAllSelected) {
-      setExcludedIds(prev => new Set([...prev, newId]));
-    }
-  }, [isAllSelected]);
-
-  const onQuestionsAdded = useCallback((newIds) => {
-    if (isAllSelected && newIds.length > 0) {
-      setExcludedIds(prev => new Set([...prev, ...newIds]));
-    }
-  }, [isAllSelected]);
 
   //태그 필터링 이벤트트
   useEffect(() => {
@@ -155,15 +139,14 @@ function Questions() {
     setUpdateQuestion({ ...question });
   }, []);
 
-  const selectedCount = isAllSelected
-    ? filterQuestions.filter(({ question }) => !excludedIds.has(question.id)).length
-    : filterQuestions.filter(({ question }) => checkedIds.has(question.id)).length;
+  const selectedCount = filterQuestions.filter(
+    ({ question }) => checkedIds.has(question.id)
+  ).length;
 
   const isAllChecked = selectedCount > 0 && selectedCount === filterQuestions.length;
 
   const handleDownloadToZip = async () => {
-    const isSelected = (question) =>
-      isAllSelected ? !excludedIds.has(question.id) : checkedIds.has(question.id);
+    const isSelected = (question) => checkedIds.has(question.id);
 
     const downloadQuestions = selectedCount > 0
       ? filterQuestions
@@ -241,8 +224,7 @@ function Questions() {
     isDeletingRef.current = true;
 
     try {
-      const isSelected = (question) =>
-        isAllSelected ? !excludedIds.has(question.id) : checkedIds.has(question.id);
+      const isSelected = (question) => checkedIds.has(question.id);
 
       const deleteImagesSet = new Set();
       const idsToDelete = filterQuestions
@@ -262,8 +244,6 @@ function Questions() {
       window.electronAPI.deleteQuestions(idsToDelete);
 
       setCheckedIds(new Set());
-      setIsAllSelected(false);
-      setExcludedIds(new Set());
 
       const handleDelete = async (imagePath) => {
         try {
@@ -326,8 +306,7 @@ function Questions() {
   const navigate = useNavigate();
   const goSelectSolve = () => {
     const toSolveTags = new Set();
-    const isSelected = (question) =>
-      isAllSelected ? !excludedIds.has(question.id) : checkedIds.has(question.id);
+    const isSelected = (question) => checkedIds.has(question.id);
 
     const toSolveQuestions = selectedCount > 0
       ? filterQuestions
@@ -375,15 +354,12 @@ function Questions() {
         handleDownloadToZip={handleDownloadToZip}
         goSelectSolve={goSelectSolve}
         checkedIds={checkedIds}
-        isAllSelected={isAllSelected}
-        excludedIds={excludedIds}
         selectedCount={selectedCount}
         handleCheckboxChange={handleCheckboxChange}
         handleAllCheckboxChange={handleAllCheckboxChange}
         isAllChecked={isAllChecked}
         displayCount={displayCount}
         onLoadMore={handleLoadMore}
-        onQuestionsAdded={onQuestionsAdded}
       />
       {/* 오버레이는 모달이 열려있을 때만 렌더링 */}
       {(insertModal || updateModal) && (
@@ -411,7 +387,6 @@ function Questions() {
           <InsertModal
             setInsertModal={setInsertModal}
             expanded={expanded}
-            onQuestionAdded={onQuestionAdded}
           />
         )}
         {updateModal && (

--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -139,19 +139,15 @@ function Questions() {
     setUpdateQuestion({ ...question });
   }, []);
 
-  const selectedCount = filterQuestions.filter(
-    ({ question }) => checkedIds.has(question.id)
-  ).length;
+  const selectedCount = checkedIds.size;
 
-  const isAllChecked = selectedCount > 0 && selectedCount === filterQuestions.length;
+  const isAllChecked = filterQuestions.length > 0 && filterQuestions.every(({ question }) => checkedIds.has(question.id));
 
   const handleDownloadToZip = async () => {
-    const isSelected = (question) => checkedIds.has(question.id);
-
-    const downloadQuestions = selectedCount > 0
-      ? filterQuestions
-          .filter(({ question }) => isSelected(question))
-          .map(({ question }) => { const { checked, id, ...rest } = question; return rest; })
+    const downloadQuestions = checkedIds.size > 0
+      ? questions
+          .filter((question) => checkedIds.has(question.id))
+          .map((question) => { const { checked, id, ...rest } = question; return rest; })
       : filterQuestions
           .map(({ question }) => { const { checked, id, ...rest } = question; return rest; });
 
@@ -224,18 +220,16 @@ function Questions() {
     isDeletingRef.current = true;
 
     try {
-      const isSelected = (question) => checkedIds.has(question.id);
-
       const deleteImagesSet = new Set();
-      const idsToDelete = filterQuestions
-        .filter(({ question }) => {
-          if (isSelected(question)) {
+      const idsToDelete = questions
+        .filter((question) => {
+          if (checkedIds.has(question.id)) {
             if (question.img) deleteImagesSet.add(question.img);
             return true;
           }
           return false;
         })
-        .map(({ question }) => question.id);
+        .map((question) => question.id);
 
       if (idsToDelete.length === 0) return;
 
@@ -306,12 +300,11 @@ function Questions() {
   const navigate = useNavigate();
   const goSelectSolve = () => {
     const toSolveTags = new Set();
-    const isSelected = (question) => checkedIds.has(question.id);
 
-    const toSolveQuestions = selectedCount > 0
-      ? filterQuestions
-          .filter(({ question }) => isSelected(question))
-          .map(({ question }) => {
+    const toSolveQuestions = checkedIds.size > 0
+      ? questions
+          .filter((question) => checkedIds.has(question.id))
+          .map((question) => {
             const { checked, tag, ...rest } = question;
             if (tag) tag.forEach((t) => toSolveTags.add(t));
             return rest;

--- a/src/pages/question/QuestionsMain.js
+++ b/src/pages/question/QuestionsMain.js
@@ -68,7 +68,7 @@ function QuestionsMain({
         <div>
           <h1 className="text-2xl font-semibold">문제 관리</h1>
           <h1 className="text-md font-normal text-gray-400">
-            총 {filterQuestions.length}개
+            총 {questions.length}개
             {selectedCount > 0 && ` 중 ${selectedCount}개 선택`}
           </h1>
         </div>

--- a/src/pages/question/QuestionsMain.js
+++ b/src/pages/question/QuestionsMain.js
@@ -8,12 +8,10 @@ function QuestionsMain({
   insertButtonClick, handleUpdateClick, handleDownloadToZip,
   deleteFilteredQuestions, goSelectSolve,
   // selection system
-  checkedIds, isAllSelected, excludedIds, selectedCount,
+  checkedIds, selectedCount,
   handleCheckboxChange, handleAllCheckboxChange, isAllChecked,
   // infinite scroll
   displayCount, onLoadMore,
-  // zip
-  onQuestionsAdded,
 }) {
   const questions = useRecoilValue(questionsAtom);
   const setQuestions = useSetRecoilState(questionsAtom);
@@ -38,7 +36,6 @@ function QuestionsMain({
         const result = await window.electronAPI.extractZip(file);
         if (result.success) {
           setQuestions([...result.questions, ...questions]);
-          onQuestionsAdded(result.questions.map(q => q.id));
         }
       } catch (error) {
         console.error("Zip 파일 처리 중 오류:", error);
@@ -50,9 +47,7 @@ function QuestionsMain({
   const visibleQuestions = filterQuestions.slice(0, displayCount);
 
   const questionsItems = visibleQuestions.map(({ question, index }) => {
-    const isChecked = isAllSelected
-      ? !excludedIds.has(question.id)
-      : checkedIds.has(question.id);
+    const isChecked = checkedIds.has(question.id);
     return (
       <QuestionItem
         key={question.id}

--- a/src/pages/question/insertModal/InsertModal.js
+++ b/src/pages/question/insertModal/InsertModal.js
@@ -8,7 +8,7 @@ import InsertModalExpanded from "./InserModalExpanded.js";
 import InsertModalCompact from "./InsertModalCompact.js";
 import { questionsAtom, allTagAtom } from "state/data.js";
 
-function InsertModal({ setInsertModal, expanded, onQuestionAdded }) {
+function InsertModal({ setInsertModal, expanded }) {
   //문제추가폼
   const [title, setTitle] = useState("");
   const [type, setType] = useState("객관식");
@@ -188,7 +188,6 @@ function InsertModal({ setInsertModal, expanded, onQuestionAdded }) {
     setImageFile(null);
     setQuestions((prevQuestions) => [question, ...prevQuestions]);
     toast.success("문제가 추가됐습니다.", { position: "top-center", autoClose: 1500 });
-    onQuestionAdded(question.id);
     window.electronAPI.appendQuestion(question);
 
     if (titleInputRef.current) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #63 

## 📝 작업 내용
- 문제 전체 선택 시 선택한 문제 ID를 set에 저장해 문제집이나 테그 선택 한 경우에도 기존 선택한 문제들을 기억 하도록 수정했습니다.
- 기존엔 Gmail 전체 선택을 참고했는데 10만 건에 대한 대용량 선택을 다루는 경우에 해당하는 방식이여서 문제어때 엔 적합하지 않다 판단했습니다.
  - 근거는 메일은 사용자 행동이 아닌 외부 요인으로 생성되어 데이터가 계속 쌓이지만 문제어때는 10만개의 문제를 만들거나 다루는 경우는 없을거라 생각했습니다.
  - 지금 DAU를 봐도 그런 경우는 악성 유저이지 않을까 싶습니다.

## ✅ 테스트 결과
- [x] 빌드 테스트 완료
- [x] 체크 및 필터 조건 테스트