### PR TITLE
fix: prevent silent auto-update install failures on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cra-template": "1.2.0",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",
+        "electron-log": "^5.4.4",
         "electron-progressbar": "^2.2.1",
         "electron-squirrel-startup": "^1.0.1",
         "electron-updater": "^6.6.2",
@@ -10012,6 +10013,15 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmmirror.com/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-progressbar": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HowAboutQuestion",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": ".",
   "main": "src/main.js",
   "files": [
@@ -19,6 +19,7 @@
     "cra-template": "1.2.0",
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.7",
+    "electron-log": "^5.4.4",
     "electron-progressbar": "^2.2.1",
     "electron-squirrel-startup": "^1.0.1",
     "electron-updater": "^6.6.2",

--- a/src/services/updateService.js
+++ b/src/services/updateService.js
@@ -38,7 +38,7 @@ function checkPreviousUpdateResult() {
       dialog.showMessageBox({
         type: 'warning',
         title: 'Update',
-        message: `업데이트(${expectedVersion}) 설치에 실패한 것으로 보입니다. 현재 버전: ${currentVersion}.\n문제가 반복되면 다운로드된 설치 파일을 직접 실행해주세요.`,
+        message: `업데이트(${expectedVersion}) 설치에 실패한 것으로 보입니다. 현재 버전: ${currentVersion}.\n문제가 반복되면 고객센터(https://www.howaboutquestion.com/support)에 문의해주세요.`,
         buttons: ['확인'],
       });
     } else {

--- a/src/services/updateService.js
+++ b/src/services/updateService.js
@@ -9,24 +9,65 @@
  */
 
 import ProgressBar from 'electron-progressbar';
-import { dialog } from 'electron';
+import { app, dialog } from 'electron';
 import pkg from 'electron-updater';
 const { autoUpdater } = pkg;
+import log from 'electron-log';
+import fs from 'fs';
+import path from 'path';
+import { userDataPath } from '../config/paths.js';
+
+const pendingUpdateFilePath = path.join(userDataPath, 'pending-update.json');
+
+log.transports.file.level = 'info';
+autoUpdater.logger = log;
 
 let progressBar;
+
+function checkPreviousUpdateResult() {
+  if (!fs.existsSync(pendingUpdateFilePath)) {
+    return;
+  }
+
+  try {
+    const { expectedVersion } = JSON.parse(fs.readFileSync(pendingUpdateFilePath, 'utf-8'));
+    const currentVersion = app.getVersion();
+
+    if (expectedVersion && expectedVersion !== currentVersion) {
+      log.warn(`Update to ${expectedVersion} appears to have failed; running version is ${currentVersion}`);
+      dialog.showMessageBox({
+        type: 'warning',
+        title: 'Update',
+        message: `업데이트(${expectedVersion}) 설치에 실패한 것으로 보입니다. 현재 버전: ${currentVersion}.\n문제가 반복되면 다운로드된 설치 파일을 직접 실행해주세요.`,
+        buttons: ['확인'],
+      });
+    } else {
+      log.info(`Update to ${expectedVersion} succeeded.`);
+    }
+  } catch (error) {
+    log.error('Failed to read pending update marker:', error);
+  } finally {
+    fs.unlinkSync(pendingUpdateFilePath);
+  }
+}
 
 /**
  * 애플리케이션의 자동 업데이트를 설정합니다.
  * 업데이트 확인, 다운로드 진행 상황, 완료 후 동작까지 핸들링합니다.
- * 
+ *
  * @param {import('electron').BrowserWindow} mainWindow - 메인 브라우저 창 인스턴스
  */
 export function setupAutoUpdater(mainWindow) {
   autoUpdater.autoDownload = false;
+  // 사용자 동의 없이 앱 종료 시 조용히(무-UI) 재설치가 시도되는 것을 막는다.
+  autoUpdater.autoInstallOnAppQuit = false;
 
-  autoUpdater.on('checking-for-update', () => {});
+  checkPreviousUpdateResult();
 
-  autoUpdater.on('update-available', () => {
+  autoUpdater.on('checking-for-update', () => log.info('Checking for update'));
+
+  autoUpdater.on('update-available', (info) => {
+    log.info(`Update available: ${info.version}`);
     dialog.showMessageBox({
       type: 'info',
       title: 'Update',
@@ -40,7 +81,7 @@ export function setupAutoUpdater(mainWindow) {
     });
   });
 
-  autoUpdater.on('update-not-available', () => {});
+  autoUpdater.on('update-not-available', () => log.info('No update available'));
 
   autoUpdater.once('download-progress', () => {
     progressBar = new ProgressBar({
@@ -52,10 +93,11 @@ export function setupAutoUpdater(mainWindow) {
       .on('aborted', () => {});
   });
 
-  autoUpdater.on('update-downloaded', () => {
+  autoUpdater.on('update-downloaded', (info) => {
     if (progressBar) {
       progressBar.setCompleted();
     }
+    log.info(`Update downloaded: ${info.version}`);
 
     dialog.showMessageBox({
       type: 'info',
@@ -65,8 +107,26 @@ export function setupAutoUpdater(mainWindow) {
     }).then((result) => {
       const { response } = result;
       if (response === 0) {
+        try {
+          fs.writeFileSync(pendingUpdateFilePath, JSON.stringify({
+            expectedVersion: info.version,
+            updatedAt: Date.now(),
+          }));
+        } catch (error) {
+          log.error('Failed to write pending update marker:', error);
+        }
         autoUpdater.quitAndInstall(false, true);
       }
+    });
+  });
+
+  autoUpdater.on('error', (error) => {
+    log.error('AutoUpdater error:', error);
+    dialog.showMessageBox({
+      type: 'error',
+      title: 'Update',
+      message: `업데이트 중 오류가 발생했습니다: ${error?.message || error}`,
+      buttons: ['확인'],
     });
   });
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #68  

## 📝 작업 내용
- electron의 log를 사용해 원인을 추적하려고 합니다.
- 작업 과정에서 사용자가 업데이트 취소를 누르면 설치를 하지 않도록 거절 로직을 추가했습니다.

## ✅ 테스트 결과
- [x] 빌드 테스트 완료
- [x] 체크 및 필터 조건 테스트